### PR TITLE
Replace Mmaps with Slices

### DIFF
--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -2,10 +2,10 @@
 /// and then contributes to entropy in parts as well
 use bellman_ce::pairing::ff::{Field, PrimeField};
 use bellman_ce::pairing::*;
+use itertools::{Itertools, MinMaxResult::MinMax};
 use log::{error, info};
 
 use generic_array::GenericArray;
-use itertools::Itertools;
 
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
@@ -23,7 +23,7 @@ pub enum AccumulatorState {
     Transformed,
 }
 
-/// The `Accumulator` is an object that participants of the ceremony contribute
+/// The `BatchedAccumulator` is an object that participants of the ceremony contribute
 /// randomness to. This object contains powers of trapdoor `tau` in G1 and in G2 over
 /// fixed generators, and additionally in G1 over two other generators of exponents
 /// `alpha` and `beta` over those fixed generators. In other words:
@@ -283,7 +283,6 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         check_output_for_correctness: CheckForCorrectness,
         parameters: &'a CeremonyParams<E>,
     ) -> bool {
-        use itertools::MinMaxResult::MinMax;
         assert_eq!(digest.len(), 64);
 
         let tau_g2_s = compute_g2_s::<E>(&digest, &key.tau_g1.0, &key.tau_g1.1, 0);
@@ -543,8 +542,6 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         check_input_for_correctness: CheckForCorrectness,
         parameters: &'a CeremonyParams<E>,
     ) -> io::Result<()> {
-        use itertools::MinMaxResult::MinMax;
-
         let mut accumulator = Self::empty(parameters);
 
         for chunk in &(0..parameters.powers_length).chunks(parameters.batch_size) {
@@ -620,8 +617,6 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         compression: UseCompression,
         parameters: &'a CeremonyParams<E>,
     ) -> io::Result<BatchedAccumulator<'a, E>> {
-        use itertools::MinMaxResult::MinMax;
-
         let mut accumulator = Self::empty(parameters);
 
         let mut tau_powers_g1 = vec![];
@@ -720,8 +715,6 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         compression: UseCompression,
         parameters: &CeremonyParams<E>,
     ) -> io::Result<()> {
-        use itertools::MinMaxResult::MinMax;
-
         for chunk in &(0..parameters.powers_length).chunks(parameters.batch_size) {
             if let MinMax(start, end) = chunk.minmax() {
                 let mut tmp_acc = BatchedAccumulator::<E> {
@@ -1178,8 +1171,6 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
 
         let mut accumulator = Self::empty(parameters);
 
-        use itertools::MinMaxResult::MinMax;
-
         for chunk in &(0..parameters.powers_length).chunks(parameters.batch_size) {
             if let MinMax(start, end) = chunk.minmax() {
                 let size = end - start + 1;
@@ -1293,8 +1284,6 @@ impl<'a, E: Engine> BatchedAccumulator<'a, E> {
         compress_the_output: UseCompression,
         parameters: &'a CeremonyParams<E>,
     ) -> io::Result<()> {
-        use itertools::MinMaxResult::MinMax;
-
         // Write the first Tau powers in chunks where every initial element is a G1 or G2 `one`
         for chunk in &(0..parameters.powers_length).chunks(parameters.batch_size) {
             if let MinMax(start, end) = chunk.minmax() {

--- a/powersoftau/src/keypair.rs
+++ b/powersoftau/src/keypair.rs
@@ -1,8 +1,6 @@
 use bellman_ce::pairing::{CurveAffine, CurveProjective, EncodedPoint, Engine};
 use blake2::{Blake2b, Digest};
 
-use memmap::{Mmap, MmapMut};
-
 use rand::{Rand, Rng};
 
 use std::io::{self, Read, Write};
@@ -169,7 +167,7 @@ impl<E: Engine> PublicKey<E> {
     /// contribution was output in compressed on uncompressed form
     pub fn write(
         &self,
-        output_map: &mut MmapMut,
+        output_map: &mut [u8],
         accumulator_was_compressed: UseCompression,
         parameters: &CeremonyParams<E>,
     ) -> io::Result<()> {
@@ -207,8 +205,6 @@ impl<E: Engine> PublicKey<E> {
 
         (&mut output_map[position..]).write_all(&self.beta_g2.into_uncompressed().as_ref())?;
 
-        output_map.flush()?;
-
         Ok(())
     }
 
@@ -216,12 +212,12 @@ impl<E: Engine> PublicKey<E> {
     /// always checked, since there aren't very many of them. Does not allow any
     /// points at infinity.
     pub fn read(
-        input_map: &Mmap,
+        input_map: &[u8],
         accumulator_was_compressed: UseCompression,
         parameters: &CeremonyParams<E>,
     ) -> Result<Self, DeserializationError> {
         fn read_uncompressed<EE: Engine, C: CurveAffine<Engine = EE, Scalar = EE::Fr>>(
-            input_map: &Mmap,
+            input_map: &[u8],
             position: usize,
         ) -> Result<C, DeserializationError> {
             let mut repr = C::Uncompressed::empty();

--- a/powersoftau/src/utils.rs
+++ b/powersoftau/src/utils.rs
@@ -6,7 +6,6 @@ use generic_array::GenericArray;
 use rand::chacha::ChaChaRng;
 use rand::{OsRng, Rand, Rng, SeedableRng};
 
-use memmap::Mmap;
 use std::io::{self, Write};
 use std::sync::Arc;
 use typenum::consts::U64;
@@ -134,7 +133,7 @@ impl<W: Write> Write for HashWriter<W> {
 /// used a specially formed writer to write to the file and calculate a hash on the fly, but memory-constrained
 /// implementation now writes without a particular order, so plain recalculation at the end
 /// of the procedure is more efficient
-pub fn calculate_hash(input_map: &Mmap) -> GenericArray<u8, U64> {
+pub fn calculate_hash(input_map: &[u8]) -> GenericArray<u8, U64> {
     let chunk_size = 1 << 30; // read by 1GB from map
     let mut hasher = Blake2b::default();
     for chunk in input_map.chunks(chunk_size) {


### PR DESCRIPTION
The crate used Mmaps everywhere, when this can be relaxed to be (mutable) slices.

This is done in preparation of extending our testing infrastructure and allowing the Accumulator to be more flexible.