### PR TITLE
Deduplicate chunks

### DIFF
--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -140,7 +140,12 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
         check_output_for_correctness: CheckForCorrectness,
         parameters: &'a CeremonyParams<E>,
     ) -> Result<()> {
-        assert_eq!(digest.len(), 64);
+        if digest.len() != 64 {
+            return Err(Error::InvalidLength {
+                expected: 64,
+                got: digest.len(),
+            });
+        }
 
         let tau_g2_s = compute_g2_s::<E>(&digest, &key.tau_g1.0, &key.tau_g1.1, 0)?;
         let alpha_g2_s = compute_g2_s::<E>(&digest, &key.alpha_g1.0, &key.alpha_g1.1, 1)?;
@@ -287,7 +292,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 }
                 info!("Done processing {} powers of tau", end);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -317,16 +322,19 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                     &output,
                 )?;
 
-                assert_eq!(
-                    before.tau_powers_g2.len(),
-                    0,
-                    "during rest of tau g1 generation tau g2 must be empty"
-                );
-                assert_eq!(
-                    after.tau_powers_g2.len(),
-                    0,
-                    "during rest of tau g1 generation tau g2 must be empty"
-                );
+                if !before.tau_powers_g2.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: before.tau_powers_g2.len(),
+                    });
+                }
+
+                if !after.tau_powers_g2.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: after.tau_powers_g2.len(),
+                    });
+                }
 
                 // Are the powers of tau correct?
                 check_same_ratio(
@@ -339,7 +347,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 }
                 info!("Done processing {} powers of tau", end);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -372,7 +380,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 )?;
                 accumulator.write_chunk(start, UseCompression::No, output)?;
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -388,25 +396,31 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                     check_input_for_correctness,
                     &input,
                 )?;
-                assert_eq!(
-                    accumulator.tau_powers_g2.len(),
-                    0,
-                    "during rest of tau g1 generation tau g2 must be empty"
-                );
-                assert_eq!(
-                    accumulator.alpha_tau_powers_g1.len(),
-                    0,
-                    "during rest of tau g1 generation alpha*tau in g1 must be empty"
-                );
-                assert_eq!(
-                    accumulator.beta_tau_powers_g1.len(),
-                    0,
-                    "during rest of tau g1 generation beta*tau in g1 must be empty"
-                );
+
+                if !accumulator.tau_powers_g2.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.tau_powers_g2.len(),
+                    });
+                }
+
+                if !accumulator.alpha_tau_powers_g1.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.alpha_tau_powers_g1.len(),
+                    });
+                }
+
+                if !accumulator.beta_tau_powers_g1.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.beta_tau_powers_g1.len(),
+                    });
+                }
 
                 accumulator.write_chunk(start, UseCompression::No, output)?;
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -445,7 +459,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                     beta_g2.extend_from_slice(&[accumulator.beta_g2]);
                 }
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -461,28 +475,31 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                     check_input_for_correctness,
                     &input,
                 )?;
-                assert_eq!(
-                    accumulator.tau_powers_g2.len(),
-                    0,
-                    "during rest of tau g1 generation tau g2 must be empty"
-                );
-                assert_eq!(
-                    accumulator.alpha_tau_powers_g1.len(),
-                    0,
-                    "during rest of tau g1 generation alpha*tau in g1 must be empty"
-                );
-                assert_eq!(
-                    accumulator.beta_tau_powers_g1.len(),
-                    0,
-                    "during rest of tau g1 generation beta*tau in g1 must be empty"
-                );
+
+                if !accumulator.tau_powers_g2.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.tau_powers_g2.len(),
+                    });
+                }
+
+                if !accumulator.alpha_tau_powers_g1.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.alpha_tau_powers_g1.len(),
+                    });
+                }
+
+                if !accumulator.beta_tau_powers_g1.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.beta_tau_powers_g1.len(),
+                    });
+                }
 
                 tau_powers_g1.extend_from_slice(&accumulator.tau_powers_g1);
-                tau_powers_g2.extend_from_slice(&accumulator.tau_powers_g2);
-                alpha_tau_powers_g1.extend_from_slice(&accumulator.alpha_tau_powers_g1);
-                beta_tau_powers_g1.extend_from_slice(&accumulator.beta_tau_powers_g1);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -516,7 +533,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 };
                 tmp_acc.write_chunk(start, compression, output)?;
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -535,7 +552,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 };
                 tmp_acc.write_chunk(start, compression, output)?;
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -811,14 +828,13 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                     Some(&key.beta),
                 );
                 accumulator.beta_g2 = accumulator.beta_g2.mul(key.beta).into_affine();
-                assert!(
-                    !accumulator.beta_g2.is_zero(),
-                    "your contribution happened to produce a point at infinity, please re-run"
-                );
+                if accumulator.beta_g2.is_zero() {
+                    return Err(Error::PointAtInfinity);
+                }
                 accumulator.write_chunk(start, compress_the_output, output)?;
                 info!("Done processing {} powers of tau", end);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -834,21 +850,20 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                     check_input_for_correctness,
                     &input,
                 )?;
-                assert_eq!(
-                    accumulator.tau_powers_g2.len(),
-                    0,
-                    "during rest of tau g1 generation tau g2 must be empty"
-                );
+                if !accumulator.tau_powers_g2.is_empty() {
+                    return Err(Error::InvalidLength {
+                        expected: 0,
+                        got: accumulator.tau_powers_g2.len(),
+                    });
+                }
 
                 let taupowers = generate_powers_of_tau::<E>(&key.tau, start, size);
                 batch_exp(&mut accumulator.tau_powers_g1, &taupowers[0..], None);
-                //accumulator.beta_g2 = accumulator.beta_g2.mul(key.beta).into_affine();
-                //assert!(!accumulator.beta_g2.is_zero(), "your contribution happened to produce a point at infinity, please re-run");
                 accumulator.write_chunk(start, compress_the_output, output)?;
 
                 info!("Done processing {} powers of tau", end);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -878,7 +893,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 accumulator.write_chunk(start, compress_the_output, output)?;
                 info!("Done processing {} powers of tau", end);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 
@@ -901,7 +916,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
                 accumulator.write_chunk(start, compress_the_output, output)?;
                 info!("Done processing {} powers of tau", end);
             } else {
-                panic!("Chunk does not have a min and max");
+                return Err(Error::InvalidChunk);
             }
         }
 

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -186,6 +186,8 @@ pub enum Error {
     VerificationError(#[from] VerificationError),
     #[error("Invalid variable length: expected {expected}, got {got}")]
     InvalidLength { expected: usize, got: usize },
+    #[error("Chunk does not have a min and max")]
+    InvalidChunk,
 }
 
 #[derive(Debug, Error)]

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -96,6 +96,7 @@ pub struct CeremonyParams<E> {
 
 impl<E: PairingEngine> CeremonyParams<E> {
     /// Constructs a new ceremony parameters object from the type of provided curve
+    /// Panics if given batch_size = 0
     pub fn new(size: usize, batch_size: usize) -> Self {
         // create the curve
         let curve = CurveParams::<E>::new();

--- a/powersoftau/src/utils.rs
+++ b/powersoftau/src/utils.rs
@@ -11,7 +11,7 @@ use rayon::prelude::*;
 use std::convert::TryInto;
 use std::io::{self, Write};
 use std::ops::AddAssign;
-use std::ops::MulAssign;
+use std::ops::Mul;
 use std::sync::Arc;
 use typenum::consts::U64;
 use zexe_algebra::{
@@ -49,27 +49,25 @@ pub fn print_hash(hash: &[u8]) {
 }
 
 /// Exponentiate a large number of points, with an optional coefficient to be applied to the
-/// exponent. Panics if provided arguments have different length.
+/// exponent.
 pub(crate) fn batch_exp<C: AffineCurve>(
     bases: &mut [C],
     exps: &[C::ScalarField],
     coeff: Option<&C::ScalarField>,
 ) {
-    // ensure the 2 vectors have the same length
-    assert_eq!(bases.len(), exps.len());
     // raise the base to the exponent and assign it back to the base
     // this will return the points as projective
     let mut points: Vec<_> = bases
         .par_iter_mut()
-        .enumerate()
-        .map(|(i, base)| {
-            let mut exp = exps[i];
-
+        .zip(exps)
+        .map(|(base, exp)| {
             // If a coefficient was provided, multiply the exponent
             // by that coefficient
-            if let Some(coeff) = coeff {
-                exp.mul_assign(coeff);
-            }
+            let exp = if let Some(coeff) = coeff {
+                exp.mul(coeff)
+            } else {
+                *exp
+            };
 
             // Raise the base to the exponent (additive notation so it is executed
             // via a multiplication)


### PR DESCRIPTION
Yet another refactor, where the double loops are replaced with if/else conditions after `parameters.powers_length`. The functions which verify that powers are generated correctly are also broken into simpler components to ease testing. As is, the chunks code should be easy to parallelize, just have to figure out how to make `par_chunks` work. There's still some room for further refactoring/better abstractions.