### PR TITLE
refactor: move utils and test helpers to shared crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,20 @@
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=serialize-uncompressed#3039fc1d5885753ea4317914744b111d614d2afc"
+source = "git+https://github.com/gakonst/zexe?branch=serde-uncompressed#71ce227d778ccbfdda05a24a43d35ec9a8b36a61"
+dependencies = [
+ "algebra-core",
+]
+
+[[package]]
+name = "algebra-core"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/zexe?branch=serde-uncompressed#71ce227d778ccbfdda05a24a43d35ec9a8b36a61"
 dependencies = [
  "derivative",
  "num-traits",
  "rand 0.7.3",
+ "rayon",
 ]
 
 [[package]]
@@ -35,12 +44,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -245,33 +248,36 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 dependencies = [
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -288,11 +294,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -382,9 +388,9 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -512,9 +518,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -528,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
+checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
@@ -592,9 +598,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 
 [[package]]
 name = "lock_api"
@@ -615,10 +621,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.3.2"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -661,7 +673,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -672,7 +684,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -682,7 +694,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -783,7 +795,7 @@ dependencies = [
 [[package]]
 name = "powersoftau"
 version = "0.2.0"
-source = "git+https://github.com/celo-org/snark-setup?rev=22b4de9087768c0ab6a628270d207e43482c9922#22b4de9087768c0ab6a628270d207e43482c9922"
+source = "git+https://github.com/celo-org/snark-setup?branch=zexe-compat#842600124a8faea4f8c8299b1939c13980c6acd9"
 dependencies = [
  "algebra",
  "blake2",
@@ -810,24 +822,18 @@ name = "powersoftau"
 version = "0.2.0"
 dependencies = [
  "algebra",
- "blake2",
  "byteorder",
  "criterion",
- "crossbeam 0.3.2",
  "generic-array",
  "gumdrop",
  "hex-literal",
  "itertools",
- "log",
  "memmap",
- "num_cpus",
- "parking_lot",
- "powersoftau 0.2.0 (git+https://github.com/celo-org/snark-setup?rev=22b4de9087768c0ab6a628270d207e43482c9922)",
+ "powersoftau 0.2.0 (git+https://github.com/celo-org/snark-setup?branch=zexe-compat)",
  "rand 0.7.3",
- "rand_chacha",
  "rayon",
- "rust-crypto",
- "thiserror",
+ "snark-utils",
+ "test-helpers",
  "typenum",
 ]
 
@@ -863,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -885,7 +891,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
 ]
 
 [[package]]
@@ -1109,9 +1115,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -1138,6 +1144,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
+name = "snark-utils"
+version = "0.1.0"
+dependencies = [
+ "algebra",
+ "blake2",
+ "criterion",
+ "crossbeam 0.7.3",
+ "generic-array",
+ "num_cpus",
+ "rand 0.7.3",
+ "rand_chacha",
+ "rayon",
+ "rust-crypto",
+ "test-helpers",
+ "thiserror",
+ "typenum",
+]
+
+[[package]]
 name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,13 +1181,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "test-helpers"
+version = "0.1.0"
+dependencies = [
+ "algebra",
+ "generic-array",
+ "rand 0.7.3",
+ "rust-crypto",
+ "snark-utils",
+ "typenum",
 ]
 
 [[package]]
@@ -1189,9 +1226,9 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -1287,9 +1324,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
  "wasm-bindgen-shared",
 ]
 
@@ -1309,9 +1346,9 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1331,9 +1368,9 @@ dependencies = [
  "anyhow",
  "heck",
  "log",
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.16",
  "wasm-bindgen-backend",
  "weedle",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [workspace]
 members = [
     "./powersoftau",
-    "./phase2"
+    "./phase2",
+    "./snark-utils",
+    "./test-helpers",
 ]
 
 [patch.crates-io]
 bellman_ce = { git = "https://github.com/matter-labs/bellman", branch = "master"  }
+algebra = { package = "algebra", git = "https://github.com/gakonst/zexe", branch = "serde-uncompressed" }

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -11,41 +11,30 @@ homepage = "https://github.com/matter-labs/powersoftau"
 repository = "https://github.com/matter-labs/powersoftau"
 
 [dependencies]
-rand_chacha = "0.2.1"
+snark-utils = { path = "../snark-utils" }
+zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
+
 rand = { version = "0.7" }
-crossbeam = "0.3.0"
-num_cpus = "1.7.0"
-blake2 = "0.6.1"
 generic-array = "0.8.3"
 typenum = "1.9.0"
 byteorder = "1.1.0"
-hex-literal = "0.1.4"
-rust-crypto = "0.2"
 memmap = "0.7.0"
 itertools = "0.8.0"
-log = "0.4.8"
 gumdrop = "0.7.0"
-
-zexe_algebra = { package = "algebra", git = "https://github.com/gakonst/zexe", branch = "serialize-uncompressed" }
 rayon = "1.3.0"
-parking_lot = "0.10.0"
-thiserror = "1.0.11"
+hex-literal = "0.1.4"
 
 [dev-dependencies]
 criterion = "0.3"
+zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel", "full"] }
+test-helpers = { path = "../test-helpers" }
 
 # add this to compare performance with old accumulators
 [dev-dependencies.powersoftau_v1]
 package = "powersoftau"
 git = "https://github.com/celo-org/snark-setup"
-rev = "22b4de9087768c0ab6a628270d207e43482c9922"
+branch = "zexe-compat"
 
 [[bench]]
-name = "math"
-harness = false
-[[bench]]
 name = "accumulator"
-harness = false
-[[bench]]
-name = "io"
 harness = false

--- a/powersoftau/benches/accumulator.rs
+++ b/powersoftau/benches/accumulator.rs
@@ -1,9 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use powersoftau::{
-    batched_accumulator::BatchedAccumulator as RawAccumulator, keypair::*, parameters::*, utils::*,
+    batched_accumulator::BatchedAccumulator as RawAccumulator, keypair::*, parameters::*,
 };
 use rand::thread_rng;
-use zexe_algebra::curves::bls12_377::Bls12_377;
+use snark_utils::*;
+use zexe_algebra::Bls12_377;
 
 use powersoftau_v1::{
     batched_accumulator::BatchedAccumulator,
@@ -77,11 +78,6 @@ fn contribute_benchmark(c: &mut Criterion) {
             &size,
             |b, size| {
                 let batch = if (batch as u32) >= 2 * 2u32.pow(*size as u32) {
-                    log::error!(
-                        "Batch {} too large for buggy `contribute`, using {} instead",
-                        batch,
-                        batch / 2
-                    );
                     2u32.pow(*size as u32) as usize
                 } else {
                     batch
@@ -157,10 +153,7 @@ fn verify_benchmark(c: &mut Criterion) {
                 setup_verify(*compressed_input, *compressed_output, &parameters);
 
             group.bench_with_input(
-                format!(
-                    "serial_{}_{}_{}",
-                    power, compressed_input, compressed_output
-                ),
+                format!("serial_{}_{}", compressed_input, compressed_output),
                 &power,
                 |b, power| {
                     let parameters_v1 = CeremonyParamsV1::<Bls12_377>::new(*power, batch);
@@ -190,10 +183,7 @@ fn verify_benchmark(c: &mut Criterion) {
             );
 
             group.bench_with_input(
-                format!(
-                    "parallel_{}_{}_{}",
-                    power, compressed_input, compressed_output
-                ),
+                format!("parallel_{}_{}", compressed_input, compressed_output),
                 &power,
                 |b, _power| {
                     b.iter(|| {

--- a/powersoftau/benches/utils.rs
+++ b/powersoftau/benches/utils.rs
@@ -3,15 +3,16 @@ use generic_array::GenericArray;
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     keypair::*,
-    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
-    raw::chunk::{buffer_size, Serializer},
-    utils::*,
+    parameters::{CeremonyParams, CheckForCorrectness},
 };
 use rand::{thread_rng, Rng};
+use snark_utils::*;
 use typenum::U64;
 use zexe_algebra::{AffineCurve, PairingEngine, ProjectiveCurve, UniformRand};
 
 use powersoftau_v1::parameters::UseCompression as UseCompressionV1;
+use snark_utils::{buffer_size, Serializer, UseCompression};
+
 // Unfortunately we need to convert datatypes from the current version
 // to be compatible to the imported version
 pub fn compat(compression: UseCompression) -> UseCompressionV1 {
@@ -76,36 +77,4 @@ pub fn generate_output<E: PairingEngine>(
 ) -> Vec<u8> {
     let expected_response_length = parameters.get_length(compressed);
     vec![0; expected_response_length]
-}
-
-pub fn random_point<C: AffineCurve>(rng: &mut impl Rng) -> C {
-    C::Projective::rand(rng).into_affine()
-}
-
-pub fn random_point_vec<C: AffineCurve>(size: usize, rng: &mut impl Rng) -> Vec<C> {
-    (0..size).map(|_| random_point(rng)).collect()
-}
-
-pub fn random_vec_buf<C: AffineCurve>(
-    size: usize,
-    compression: UseCompression,
-) -> (Vec<C>, Vec<u8>) {
-    let mut rng = thread_rng();
-    let elements: Vec<C> = random_point_vec(size, &mut rng);
-    let len = buffer_size::<C>(compression) * size;
-    let mut buf = vec![0; len];
-    buf.write_batch(&elements, compression).unwrap();
-    (elements, buf)
-}
-
-// same as above but does not write
-pub fn random_vec_empty_buf<C: AffineCurve>(
-    size: usize,
-    compression: UseCompression,
-) -> (Vec<C>, Vec<u8>) {
-    let mut rng = thread_rng();
-    let elements: Vec<C> = random_point_vec(size, &mut rng);
-    let len = buffer_size::<C>(compression) * size;
-    let buf = vec![0; len];
-    (elements, buf)
 }

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -1,16 +1,15 @@
 use generic_array::GenericArray;
 /// Memory constrained accumulator that checks parts of the initial information in parts that fit to memory
 /// and then contributes to entropy in parts as well
-use log::info;
 use typenum::consts::U64;
 use zexe_algebra::PairingEngine as Engine;
 
 use super::{
     keypair::{PrivateKey, PublicKey},
-    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
+    parameters::{CeremonyParams, CheckForCorrectness},
     raw::raw_accumulator,
-    utils::{blank_hash, Result},
 };
+use snark_utils::{blank_hash, Result, UseCompression};
 /// The `BatchedAccumulator` is an object that participants of the ceremony contribute
 /// randomness to. This object contains powers of trapdoor `tau` in G1 and in G2 over
 /// fixed generators, and additionally in G1 over two other generators of exponents
@@ -73,7 +72,6 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
             key,
             parameters,
         )?;
-        info!("Contributed to the accumulator!");
         Ok(())
     }
 
@@ -152,14 +150,10 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::{
-        batch_exp, calculate_hash, generate_powers_of_tau,
-        test_helpers::{random_point, random_point_vec},
-    };
     use rand::thread_rng;
-    use zexe_algebra::curves::{
-        bls12_377::Bls12_377, bls12_381::Bls12_381, sw6::SW6, AffineCurve, ProjectiveCurve,
-    };
+    use snark_utils::{batch_exp, calculate_hash, generate_powers_of_tau};
+    use test_helpers::{random_point, random_point_vec};
+    use zexe_algebra::{AffineCurve, Bls12_377, Bls12_381, ProjectiveCurve, SW6};
 
     #[test]
     fn serialize_multiple_batches() {

--- a/powersoftau/src/bin/powersoftau.rs
+++ b/powersoftau/src/bin/powersoftau.rs
@@ -3,13 +3,10 @@ use powersoftau::cli_common::{
     contribute, new_challenge, transform, Command, CurveKind, PowersOfTauOpts,
 };
 use powersoftau::parameters::CeremonyParams;
-use powersoftau::utils::{beacon_randomness, get_rng, user_system_randomness};
+use snark_utils::{beacon_randomness, get_rng, user_system_randomness};
 
 use std::process;
-use zexe_algebra::{
-    curves::{bls12_377::Bls12_377, bls12_381::Bls12_381, sw6::SW6},
-    PairingEngine as Engine,
-};
+use zexe_algebra::{Bls12_377, Bls12_381, PairingEngine as Engine, SW6};
 
 #[macro_use]
 extern crate hex_literal;

--- a/powersoftau/src/cli_common/contribute.rs
+++ b/powersoftau/src/cli_common/contribute.rs
@@ -1,11 +1,11 @@
 use crate::{
     batched_accumulator::BatchedAccumulator,
     keypair::keypair,
-    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
-    utils::{calculate_hash, print_hash},
+    parameters::{CeremonyParams, CheckForCorrectness},
 };
 use memmap::*;
 use rand::Rng;
+use snark_utils::{calculate_hash, print_hash, UseCompression};
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use zexe_algebra::PairingEngine as Engine;

--- a/powersoftau/src/cli_common/new_challenge.rs
+++ b/powersoftau/src/cli_common/new_challenge.rs
@@ -1,6 +1,6 @@
 use crate::batched_accumulator::BatchedAccumulator;
-use crate::parameters::{CeremonyParams, UseCompression};
-use crate::utils::{blank_hash, calculate_hash, print_hash};
+use crate::parameters::CeremonyParams;
+use snark_utils::{blank_hash, calculate_hash, print_hash, UseCompression};
 
 use memmap::*;
 use std::fs::OpenOptions;

--- a/powersoftau/src/cli_common/transform.rs
+++ b/powersoftau/src/cli_common/transform.rs
@@ -1,10 +1,10 @@
 use crate::{
     batched_accumulator::BatchedAccumulator,
     keypair::PublicKey,
-    parameters::{CeremonyParams, CheckForCorrectness, UseCompression},
-    utils::{calculate_hash, print_hash},
+    parameters::{CeremonyParams, CheckForCorrectness},
 };
 use memmap::*;
+use snark_utils::{calculate_hash, print_hash, UseCompression};
 use std::fs::OpenOptions;
 use zexe_algebra::PairingEngine as Engine;
 

--- a/powersoftau/src/keypair.rs
+++ b/powersoftau/src/keypair.rs
@@ -1,8 +1,8 @@
 use rand::Rng;
 use zexe_algebra::{AffineCurve, PairingEngine, ProjectiveCurve, UniformRand};
 
-use super::parameters::{CeremonyParams, Error, UseCompression};
-use super::utils::compute_g2_s;
+use super::parameters::CeremonyParams;
+use snark_utils::{compute_g2_s, Error, UseCompression};
 
 /// Contains terms of the form (s<sub>1</sub>, s<sub>1</sub><sup>x</sup>, H(s<sub>1</sub><sup>x</sup>)<sub>2</sub>, H(s<sub>1</sub><sup>x</sup>)<sub>2</sub><sup>x</sup>)
 /// for all x in τ, α and β, and some s chosen randomly by its creator. The function H "hashes into" the group G2. No points in the public key may be the identity.
@@ -239,12 +239,11 @@ fn read_elements<G: AffineCurve>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        parameters::{CurveParams, ElementType},
-        utils::test_helpers::random_point_vec,
-    };
+    use crate::parameters::CurveParams;
     use rand::{thread_rng, Rng};
-    use zexe_algebra::curves::{bls12_377::Bls12_377, bls12_381::Bls12_381, sw6::SW6};
+    use snark_utils::ElementType;
+    use test_helpers::random_point_vec;
+    use zexe_algebra::{bls12_377::Bls12_377, bls12_381::Bls12_381, sw6::SW6};
 
     #[test]
     fn test_pubkey_serialization_bls12_381() {

--- a/powersoftau/src/lib.rs
+++ b/powersoftau/src/lib.rs
@@ -3,4 +3,3 @@ pub mod cli_common;
 pub mod keypair;
 pub mod parameters;
 pub mod raw;
-pub mod utils;

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -1,8 +1,6 @@
-use std::fmt;
-use std::io;
+use snark_utils::{ElementType, UseCompression};
 use std::marker::PhantomData;
-use thiserror::Error;
-use zexe_algebra::{CanonicalSerialize, PairingEngine, SerializationError, Zero};
+use zexe_algebra::{CanonicalSerialize, PairingEngine, Zero};
 
 /// The sizes of the group elements of a curve
 #[derive(Clone, PartialEq, Eq, Default, Debug)]
@@ -164,13 +162,6 @@ impl<E: PairingEngine> CeremonyParams<E> {
     }
 }
 
-/// Determines if point compression should be used.
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum UseCompression {
-    Yes,
-    No,
-}
-
 /// Determines if points should be checked for correctness during deserialization.
 /// This is not necessary for participants, because a transcript verifier can
 /// check this theirself.
@@ -180,69 +171,10 @@ pub enum CheckForCorrectness {
     No,
 }
 
-/// Errors that might occur during deserialization.
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Disk IO error: {0}")]
-    IoError(#[from] io::Error),
-    #[error("Serialization error in Zexe: {0}")]
-    ZexeSerializationError(#[from] SerializationError),
-    #[error("Got point at infinity")]
-    PointAtInfinity,
-    #[error("Index of {0} must not exceed {1} (got {2}.")]
-    PositionError(ElementType, usize, usize),
-    #[error("Error during verification: {0}")]
-    VerificationError(#[from] VerificationError),
-    #[error("Invalid variable length: expected {expected}, got {got}")]
-    InvalidLength { expected: usize, got: usize },
-    #[error("Chunk does not have a min and max")]
-    InvalidChunk,
-}
-
-#[derive(Debug, Error)]
-pub enum VerificationError {
-    #[error("Invalid ratio! Context: {0}")]
-    /// The ratio check via the pairing of the provided elements failed
-    InvalidRatio(&'static str),
-    #[error("Invalid generator for {0} powers")]
-    /// The first power of Tau was not the generator of that group
-    InvalidGenerator(ElementType),
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum ElementType {
-    TauG1,
-    TauG2,
-    AlphaG1,
-    BetaG1,
-    BetaG2,
-}
-
-impl fmt::Display for UseCompression {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            UseCompression::Yes => write!(f, "Yes"),
-            UseCompression::No => write!(f, "No"),
-        }
-    }
-}
-
-impl fmt::Display for ElementType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ElementType::TauG1 => write!(f, "TauG1"),
-            ElementType::TauG2 => write!(f, "TauG2"),
-            ElementType::AlphaG1 => write!(f, "AlphaG1"),
-            ElementType::BetaG1 => write!(f, "BetaG1"),
-            ElementType::BetaG2 => write!(f, "BetaG2"),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zexe_algebra::curves::{bls12_377::Bls12_377, bls12_381::Bls12_381, sw6::SW6};
+    use zexe_algebra::{Bls12_377, Bls12_381, SW6};
 
     #[test]
     fn params_sizes() {

--- a/powersoftau/src/raw/mod.rs
+++ b/powersoftau/src/raw/mod.rs
@@ -1,2 +1,1 @@
-pub mod chunk;
 pub mod raw_accumulator;

--- a/snark-utils/Cargo.toml
+++ b/snark-utils/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "snark-utils"
+version = "0.1.0"
+authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thiserror = "1.0.11"
+zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
+rayon = "1.3.0"
+
+# crypto lower-level crates
+rand = "0.7.3"
+rand_chacha = "0.2.1"
+typenum = "1.9.0"
+rust-crypto = "0.2"
+blake2 = "0.6.1"
+generic-array = "0.8.3"
+crossbeam = "0.7.3"
+num_cpus = "1.12.0"
+
+[dev-dependencies]
+criterion = "0.3.1"
+test-helpers = { path = "../test-helpers" }
+zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel", "full"] }
+
+[[bench]]
+name = "math"
+harness = false
+[[bench]]
+name = "io"
+harness = false

--- a/snark-utils/README.md
+++ b/snark-utils/README.md
@@ -1,0 +1,5 @@
+# SNARK MPC Utils
+
+Utilities for building MPC Ceremonies for large SNARKs with Zexe.
+Provides traits for batched writing and reading Group Elements
+to buffers.

--- a/snark-utils/benches/io.rs
+++ b/snark-utils/benches/io.rs
@@ -1,10 +1,12 @@
 #![allow(clippy::unit_arg)]
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use powersoftau::{parameters::*, raw::chunk::*, utils::*};
-use zexe_algebra::{curves::bls12_377::Bls12_377, AffineCurve, PairingEngine};
+use zexe_algebra::{AffineCurve, Bls12_377, PairingEngine};
 
-mod utils;
-use utils::*;
+use snark_utils::{
+    buffer_size, BatchDeserializer, ParBatchDeserializer, Result, Serializer, UseCompression,
+};
+
+use test_helpers::*;
 
 /// Benchmark comparing reading compressed/uncompressed points in parallel & serial
 /// with preallocated vectors and allocating new vectors each time.

--- a/snark-utils/src/elements.rs
+++ b/snark-utils/src/elements.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+
+/// Determines if point compression should be used.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum UseCompression {
+    Yes,
+    No,
+}
+
+impl fmt::Display for UseCompression {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UseCompression::Yes => write!(f, "Yes"),
+            UseCompression::No => write!(f, "No"),
+        }
+    }
+}
+
+// todo: remove this, we can always get the size of the element
+// from the `buffer_size` method
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ElementType {
+    TauG1,
+    TauG2,
+    AlphaG1,
+    BetaG1,
+    BetaG2,
+}
+
+impl fmt::Display for ElementType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ElementType::TauG1 => write!(f, "TauG1"),
+            ElementType::TauG2 => write!(f, "TauG2"),
+            ElementType::AlphaG1 => write!(f, "AlphaG1"),
+            ElementType::BetaG1 => write!(f, "BetaG1"),
+            ElementType::BetaG2 => write!(f, "BetaG2"),
+        }
+    }
+}

--- a/snark-utils/src/errors.rs
+++ b/snark-utils/src/errors.rs
@@ -1,0 +1,36 @@
+use std::io;
+use thiserror::Error;
+use zexe_algebra::SerializationError;
+
+use crate::ElementType;
+
+/// Errors that might occur during deserialization.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Disk IO error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("Serialization error in Zexe: {0}")]
+    ZexeSerializationError(#[from] SerializationError),
+    #[error("Got point at infinity")]
+    PointAtInfinity,
+    #[error("Index of {0} must not exceed {1} (got {2}.")]
+    PositionError(ElementType, usize, usize),
+    #[error("Error during verification: {0}")]
+    VerificationError(#[from] VerificationError),
+    #[error("Invalid variable length: expected {expected}, got {got}")]
+    InvalidLength { expected: usize, got: usize },
+    #[error("Chunk does not have a min and max")]
+    InvalidChunk,
+}
+
+// todo: make this more detailed so that we can know which 
+// exact pairing ratio check failed
+#[derive(Debug, Error)]
+pub enum VerificationError {
+    #[error("Invalid ratio! Context: {0}")]
+    /// The ratio check via the pairing of the provided elements failed
+    InvalidRatio(&'static str),
+    #[error("Invalid generator for {0} powers")]
+    /// The first power of Tau was not the generator of that group
+    InvalidGenerator(ElementType),
+}

--- a/snark-utils/src/io.rs
+++ b/snark-utils/src/io.rs
@@ -1,5 +1,5 @@
 //! Utilities for writing and reading group elements to buffers in parallel
-use crate::{parameters::UseCompression, utils::Result};
+use crate::{Result, UseCompression};
 use rayon::prelude::*;
 use zexe_algebra::AffineCurve;
 
@@ -195,9 +195,9 @@ impl Deserializer for [u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_helpers::random_point_vec;
+    use crate::helpers::test_helpers::random_point_vec;
     use rand::thread_rng;
-    use zexe_algebra::curves::bls12_377::{G1Affine, G2Affine};
+    use zexe_algebra::bls12_377::{G1Affine, G2Affine};
 
     #[test]
     fn read_write_single() {

--- a/snark-utils/src/lib.rs
+++ b/snark-utils/src/lib.rs
@@ -1,0 +1,16 @@
+//! # SNARK MPC Utils
+//!
+//! Utilities for building MPC Ceremonies for large SNARKs with Zexe.
+//! Provides traits for batched writing and reading Group Elements
+//! to buffers.
+pub mod errors;
+pub use errors::{Error, VerificationError};
+
+mod elements;
+pub use elements::{ElementType, UseCompression};
+
+mod helpers;
+pub use helpers::*;
+
+mod io;
+pub use io::{buffer_size, BatchDeserializer, Deserializer, ParBatchDeserializer, Serializer};

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test-helpers"
+version = "0.1.0"
+authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+snark-utils = { path = "../snark-utils" }
+zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
+
+rand = "0.7.3"
+typenum = "1.9.0"
+rust-crypto = "0.2"
+generic-array = "0.8.3"

--- a/test-helpers/README.md
+++ b/test-helpers/README.md
@@ -1,0 +1,3 @@
+# Test Helpers
+
+Various utility methods used in tests and benchmarks across the other crates

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,0 +1,46 @@
+//! Helpers crate to be consumed in tests and benchmarks
+#![allow(unused)]
+use generic_array::GenericArray;
+use rand::{thread_rng, Rng};
+use typenum::U64;
+use zexe_algebra::{AffineCurve, PairingEngine, ProjectiveCurve, UniformRand};
+
+use snark_utils::{buffer_size, Serializer, UseCompression};
+
+/// returns a random affine curve point from the provided rng
+pub fn random_point<C: AffineCurve>(rng: &mut impl Rng) -> C {
+    C::Projective::rand(rng).into_affine()
+}
+
+/// returns a random affine curve point vector from the provided rng
+pub fn random_point_vec<C: AffineCurve>(size: usize, rng: &mut impl Rng) -> Vec<C> {
+    (0..size).map(|_| random_point(rng)).collect()
+}
+
+/// returns a random affine curve point vector and serializes it
+/// to a buffer with the provided compression format
+pub fn random_vec_buf<C: AffineCurve>(
+    size: usize,
+    compression: UseCompression,
+) -> (Vec<C>, Vec<u8>) {
+    let mut rng = thread_rng();
+    let elements: Vec<C> = random_point_vec(size, &mut rng);
+    let len = buffer_size::<C>(compression) * size;
+    let mut buf = vec![0; len];
+    buf.write_batch(&elements, compression).unwrap();
+    (elements, buf)
+}
+
+/// returns a random affine curve point vector and
+/// returns an empty buffer with sufficient size
+/// to write that vector to it
+pub fn random_vec_empty_buf<C: AffineCurve>(
+    size: usize,
+    compression: UseCompression,
+) -> (Vec<C>, Vec<u8>) {
+    let mut rng = thread_rng();
+    let elements: Vec<C> = random_point_vec(size, &mut rng);
+    let len = buffer_size::<C>(compression) * size;
+    let buf = vec![0; len];
+    (elements, buf)
+}


### PR DESCRIPTION
This should speed up compilation times, as the compiler will try to cache these compiled deps. 

Also Zexe's latest master merge had breaking changes due to the algebra crate refactor, so we fix these as well

* snark-utils: contains the serialization/deserialization helpers
  plus any necessary utilities around generating powers of tau,
  exponentiationg, multiexp etc.
* test-helpers: contains certain test utilities which are commonly
  seen, such as generating random points, vectors and buffers