### PR TITLE
fix cargo audit error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
             cargo clippy --all-targets --all-features -- -D warnings
       - run:
           name: Audit Dependencies
-          command: cargo audit
+          command: cargo audit --ignore RUSTSEC-2019-0019

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,10 +54,22 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53bf612c0f2839b7e764ebac65d6cb985f7c6812de399d0728038f4b1da141bc"
 dependencies = [
- "byte-tools",
- "crypto-mac",
- "digest",
- "generic-array",
+ "byte-tools 0.2.0",
+ "crypto-mac 0.4.0",
+ "digest 0.6.2",
+ "generic-array 0.8.3",
+]
+
+[[package]]
+name = "blake2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
+dependencies = [
+ "byte-tools 0.3.1",
+ "crypto-mac 0.7.0",
+ "digest 0.8.1",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -83,6 +95,12 @@ name = "byte-tools"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -259,7 +277,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
 dependencies = [
  "constant_time_eq",
- "generic-array",
+ "generic-array 0.8.3",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+dependencies = [
+ "generic-array 0.12.3",
+ "subtle",
 ]
 
 [[package]]
@@ -301,7 +329,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 dependencies = [
- "generic-array",
+ "generic-array 0.8.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -329,6 +366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 dependencies = [
  "nodrop",
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
  "typenum",
 ]
 
@@ -527,6 +573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,10 +620,10 @@ version = "0.2.0"
 source = "git+https://github.com/celo-org/snark-setup?branch=zexe-compat#842600124a8faea4f8c8299b1939c13980c6acd9"
 dependencies = [
  "algebra",
- "blake2",
+ "blake2 0.6.1",
  "byteorder",
  "crossbeam 0.3.2",
- "generic-array",
+ "generic-array 0.8.3",
  "gumdrop",
  "hex-literal",
  "itertools",
@@ -592,9 +644,7 @@ name = "powersoftau"
 version = "0.2.0"
 dependencies = [
  "algebra",
- "byteorder",
  "criterion",
- "generic-array",
  "gumdrop",
  "hex-literal",
  "itertools",
@@ -604,7 +654,6 @@ dependencies = [
  "rayon",
  "snark-utils",
  "test-helpers",
- "typenum",
 ]
 
 [[package]]
@@ -802,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7246cd0a0a6ec2239a5405b2b16e3f404fa0dcc6d28f5f5b877bf80e33e0f294"
 
 [[package]]
 name = "rust-crypto"
@@ -909,10 +958,9 @@ name = "snark-utils"
 version = "0.1.0"
 dependencies = [
  "algebra",
- "blake2",
+ "blake2 0.8.1",
  "criterion",
  "crossbeam 0.7.3",
- "generic-array",
  "num_cpus",
  "rand 0.7.3",
  "rand_chacha",
@@ -928,6 +976,12 @@ name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
@@ -956,7 +1010,6 @@ name = "test-helpers"
 version = "0.1.0"
 dependencies = [
  "algebra",
- "generic-array",
  "rand 0.7.3",
  "rust-crypto",
  "snark-utils",

--- a/phase2/Cargo.toml
+++ b/phase2/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.4"
 byteorder = "1"
 exitcode = "1.1.2"
 blake2-rfc = "0.2"
-blake2 = "0.6.1"
+blake2 = "0.8.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-bigint = "0.2.3"

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -12,16 +12,15 @@ repository = "https://github.com/matter-labs/powersoftau"
 
 [dependencies]
 snark-utils = { path = "../snark-utils" }
-zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
 
+zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
 rand = { version = "0.7" }
-generic-array = "0.8.3"
-typenum = "1.9.0"
-byteorder = "1.1.0"
 memmap = "0.7.0"
 itertools = "0.8.0"
-gumdrop = "0.7.0"
 rayon = "1.3.0"
+
+# used for the CLIs
+gumdrop = "0.7.0"
 hex-literal = "0.1.4"
 
 [dev-dependencies]

--- a/powersoftau/benches/utils.rs
+++ b/powersoftau/benches/utils.rs
@@ -1,17 +1,14 @@
-#![allow(unused)]
-use generic_array::GenericArray;
 use powersoftau::{
     batched_accumulator::BatchedAccumulator,
     keypair::*,
     parameters::{CeremonyParams, CheckForCorrectness},
 };
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 use snark_utils::*;
-use typenum::U64;
-use zexe_algebra::{AffineCurve, PairingEngine, ProjectiveCurve, UniformRand};
+use zexe_algebra::PairingEngine;
 
 use powersoftau_v1::parameters::UseCompression as UseCompressionV1;
-use snark_utils::{buffer_size, Serializer, UseCompression};
+use snark_utils::UseCompression;
 
 // Unfortunately we need to convert datatypes from the current version
 // to be compatible to the imported version

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -1,7 +1,5 @@
-use generic_array::GenericArray;
 /// Memory constrained accumulator that checks parts of the initial information in parts that fit to memory
 /// and then contributes to entropy in parts as well
-use typenum::consts::U64;
 use zexe_algebra::PairingEngine as Engine;
 
 use super::{
@@ -9,7 +7,7 @@ use super::{
     parameters::{CeremonyParams, CheckForCorrectness},
     raw::raw_accumulator,
 };
-use snark_utils::{blank_hash, Result, UseCompression};
+use snark_utils::{blank_hash, GenericArray, Result, UseCompression, U64};
 /// The `BatchedAccumulator` is an object that participants of the ceremony contribute
 /// randomness to. This object contains powers of trapdoor `tau` in G1 and in G2 over
 /// fixed generators, and additionally in G1 over two other generators of exponents

--- a/snark-utils/Cargo.toml
+++ b/snark-utils/Cargo.toml
@@ -14,12 +14,11 @@ rayon = "1.3.0"
 # crypto lower-level crates
 rand = "0.7.3"
 rand_chacha = "0.2.1"
-typenum = "1.9.0"
+typenum = "1.11.2"
 rust-crypto = "0.2"
-blake2 = "0.6.1"
-generic-array = "0.8.3"
 crossbeam = "0.7.3"
 num_cpus = "1.12.0"
+blake2 = "0.8.1"
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/snark-utils/src/errors.rs
+++ b/snark-utils/src/errors.rs
@@ -23,7 +23,7 @@ pub enum Error {
     InvalidChunk,
 }
 
-// todo: make this more detailed so that we can know which 
+// todo: make this more detailed so that we can know which
 // exact pairing ratio check failed
 #[derive(Debug, Error)]
 pub enum VerificationError {

--- a/snark-utils/src/helpers.rs
+++ b/snark-utils/src/helpers.rs
@@ -1,11 +1,10 @@
-use blake2::{Blake2b, Digest};
-use generic_array::GenericArray;
+use crate::errors::{Error, VerificationError};
+use blake2::{digest::generic_array::GenericArray, Blake2b, Digest};
+use crypto::digest::Digest as CryptoDigest;
+use crypto::sha2::Sha256;
 use rand::{rngs::OsRng, thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
-use crate::errors::{Error, VerificationError};
-use crypto::digest::Digest as CryptoDigest;
-use crypto::sha2::Sha256;
 use rayon::prelude::*;
 use std::convert::TryInto;
 use std::io::{self, Write};

--- a/snark-utils/src/lib.rs
+++ b/snark-utils/src/lib.rs
@@ -14,3 +14,7 @@ pub use helpers::*;
 
 mod io;
 pub use io::{buffer_size, BatchDeserializer, Deserializer, ParBatchDeserializer, Serializer};
+
+// Re-exports for handling hashes
+pub use blake2::digest::generic_array::GenericArray;
+pub use typenum::U64;

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -11,6 +11,5 @@ snark-utils = { path = "../snark-utils" }
 zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
 
 rand = "0.7.3"
-typenum = "1.9.0"
+typenum = "1.11.2"
 rust-crypto = "0.2"
-generic-array = "0.8.3"

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,9 +1,6 @@
 //! Helpers crate to be consumed in tests and benchmarks
-#![allow(unused)]
-use generic_array::GenericArray;
 use rand::{thread_rng, Rng};
-use typenum::U64;
-use zexe_algebra::{AffineCurve, PairingEngine, ProjectiveCurve, UniformRand};
+use zexe_algebra::{AffineCurve, ProjectiveCurve, UniformRand};
 
 use snark_utils::{buffer_size, Serializer, UseCompression};
 


### PR DESCRIPTION
We do not use blake2 version 0.6.1 anywhere directly anymore, so we temporarily silence the warning.