### PR TITLE
perf(io): Make rayon optional and simplify traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ challenge*
 response*
 phase1radix2m*
 tmp_*
+.vscode

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -11,8 +11,7 @@ homepage = "https://github.com/matter-labs/powersoftau"
 repository = "https://github.com/matter-labs/powersoftau"
 
 [dependencies]
-snark-utils = { path = "../snark-utils" }
-
+snark-utils = { path = "../snark-utils", features = ["parallel"] }
 zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
 rand = { version = "0.7" }
 memmap = "0.7.0"

--- a/powersoftau/src/bin/powersoftau.rs
+++ b/powersoftau/src/bin/powersoftau.rs
@@ -6,6 +6,7 @@ use powersoftau::parameters::CeremonyParams;
 use snark_utils::{beacon_randomness, get_rng, user_system_randomness};
 
 use std::process;
+use std::time::Instant;
 use zexe_algebra::{Bls12_377, Bls12_381, PairingEngine as Engine, SW6};
 
 #[macro_use]
@@ -13,6 +14,7 @@ extern crate hex_literal;
 
 fn main() {
     let opts: PowersOfTauOpts = PowersOfTauOpts::parse_args_default_or_exit();
+
     match opts.curve_kind {
         CurveKind::Bls12_381 => execute_cmd::<Bls12_381>(opts),
         CurveKind::Bls12_377 => execute_cmd::<Bls12_377>(opts),
@@ -23,12 +25,13 @@ fn main() {
 fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
     let parameters = CeremonyParams::<E>::new(opts.power, opts.batch_size);
 
-    let command = opts.command.unwrap_or_else(|| {
+    let command = opts.clone().command.unwrap_or_else(|| {
         eprintln!("No command was provided.");
         eprintln!("{}", PowersOfTauOpts::usage());
         process::exit(2)
     });
 
+    let now = Instant::now();
     match command {
         Command::New(opt) => {
             new_challenge(&opt.challenge_fname, &parameters);
@@ -56,4 +59,11 @@ fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
             );
         }
     };
+
+    let new_now = Instant::now();
+    println!(
+        "Executing {:?} took: {:?}",
+        opts,
+        new_now.duration_since(now)
+    );
 }

--- a/snark-utils/Cargo.toml
+++ b/snark-utils/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 thiserror = "1.0.11"
 zexe_algebra = { package = "algebra", version = "0.1.0", features = ["parallel"] }
 zexe_fft = { package = "ff-fft", version = "0.1.0", features = ["parallel"] }
-rayon = "1.3.0"
+rayon = { version = "1.3.0", optional = true }
 
 # crypto lower-level crates
 rand = "0.7.3"
@@ -34,3 +34,7 @@ harness = false
 [[bench]]
 name = "io"
 harness = false
+
+[features]
+default = []
+parallel = ["rayon", "zexe_algebra/parallel", "zexe_fft/parallel"]

--- a/snark-utils/benches/io.rs
+++ b/snark-utils/benches/io.rs
@@ -1,13 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use zexe_algebra::{AffineCurve, Bls12_377, PairingEngine};
 
-use snark_utils::{
-    buffer_size, BatchDeserializer, ParBatchDeserializer, Result, Serializer, UseCompression,
-};
+use snark_utils::{Deserializer, Serializer, UseCompression};
 
 use test_helpers::*;
 
-/// Benchmark comparing reading compressed/uncompressed points in parallel & serial
+/// Benchmark comparing reading compressed/uncompressed points
 /// with preallocated vectors and allocating new vectors each time.
 /// Preliminary results show:
 /// - reading compressed elements is MUCH slower than uncompressed
@@ -19,25 +17,18 @@ use test_helpers::*;
 ///   no computational bottleneck, hence the parallelism ends up introducing more overhead than benefit
 fn read<C: AffineCurve>(c: &mut Criterion, el_type: &str) {
     let mut group = c.benchmark_group(format!("read_batched_{}", el_type));
-    let els = (1..14)
+    group.sample_size(10);
+    let els = (8..11)
         .map(|i| 2u32.pow(i) as usize)
         .collect::<Vec<usize>>();
 
-    for compression in &[UseCompression::Yes, UseCompression::No] {
+    for compression in &[UseCompression::Yes] {
+        // , UseCompression::No] {
         for num_els in &els {
             group.throughput(Throughput::Elements(*num_els as u64));
 
             group.bench_with_input(
-                format!("parallel_{}", compression),
-                &num_els,
-                |b, _num_els| {
-                    let (_, buf) = random_vec_buf::<C>(*num_els, *compression);
-                    b.iter(|| buf.par_read_batch::<C>(*compression).unwrap());
-                },
-            );
-
-            group.bench_with_input(
-                format!("serial_{}", compression),
+                format!("normal_{}", compression),
                 &num_els,
                 |b, _num_els| {
                     let (_, buf) = random_vec_buf::<C>(*num_els, *compression);
@@ -46,23 +37,11 @@ fn read<C: AffineCurve>(c: &mut Criterion, el_type: &str) {
             );
 
             group.bench_with_input(
-                format!("preallocated_parallel_{}", compression),
+                format!("preallocated_{}", compression),
                 &num_els,
                 |b, _num_els| {
+                    let (mut elements, buf) = random_vec_buf(*num_els, *compression);
                     b.iter(|| {
-                        let (mut elements, buf) = random_vec_buf(*num_els, *compression);
-                        buf.par_read_batch_preallocated::<C>(&mut elements, *compression)
-                            .unwrap()
-                    });
-                },
-            );
-
-            group.bench_with_input(
-                format!("preallocated_serial_{}", compression),
-                &num_els,
-                |b, _num_els| {
-                    b.iter(|| {
-                        let (mut elements, buf) = random_vec_buf(*num_els, *compression);
                         buf.read_batch_preallocated::<C>(&mut elements, *compression)
                             .unwrap()
                     });
@@ -78,44 +57,20 @@ fn read<C: AffineCurve>(c: &mut Criterion, el_type: &str) {
 /// We observe that after ~512 element buffers, the parallel version starts to take over
 fn write<C: AffineCurve>(c: &mut Criterion, el_type: &str) {
     let mut group = c.benchmark_group(format!("write_batched_{}", el_type));
-    let els = (1..14)
+    let els = (8..11)
         .map(|i| 2u32.pow(i) as usize)
         .collect::<Vec<usize>>();
-    for compression in &[UseCompression::Yes, UseCompression::No] {
+    group.sample_size(10);
+    for compression in &[UseCompression::Yes] {
+        // , UseCompression::No] {
         for num_els in &els {
             let (elements, mut buf) = random_vec_empty_buf(*num_els, *compression);
 
             group.throughput(Throughput::Elements(*num_els as u64));
 
-            group.bench_with_input(
-                format!("parallel_{}", compression),
-                &num_els,
-                |b, _num_els| {
-                    b.iter(|| buf.write_batch::<C>(&elements, *compression).unwrap());
-                },
-            );
-
-            group.bench_with_input(
-                format!("serial_{}", compression),
-                &num_els,
-                |b, _num_els| {
-                    fn write_batch_serial<C: AffineCurve>(
-                        buf: &mut [u8],
-                        elements: &[C],
-                        compression: UseCompression,
-                    ) -> Result<()> {
-                        let size = buffer_size::<C>(compression);
-                        buf.chunks_mut(size)
-                            .zip(elements)
-                            .map(|(buf, element)| {
-                                (&mut buf[0..size]).write_element(element, compression)?;
-                                Ok(())
-                            })
-                            .collect()
-                    }
-                    b.iter(|| write_batch_serial::<C>(&mut buf, &elements, *compression).unwrap());
-                },
-            );
+            group.bench_with_input(format!("{}", compression), &num_els, |b, _num_els| {
+                b.iter(|| buf.write_batch::<C>(&elements, *compression).unwrap());
+            });
         }
     }
     group.finish()

--- a/snark-utils/src/lib.rs
+++ b/snark-utils/src/lib.rs
@@ -16,8 +16,10 @@ mod helpers;
 pub use helpers::*;
 
 mod io;
-pub use io::{buffer_size, BatchDeserializer, Deserializer, ParBatchDeserializer, Serializer};
+pub use io::{buffer_size, Deserializer, Serializer};
 
 // Re-exports for handling hashes
 pub use blake2::digest::generic_array::GenericArray;
 pub use typenum::U64;
+
+pub use zexe_fft::{cfg_chunks, cfg_into_iter, cfg_iter_mut};


### PR DESCRIPTION
We compared the performance of both contributing and verifying the
accumulator with large numbers of powers, verification is about 25%
faster, and contributing is 40% faster with parallel features. As a
result the parallel-vs-serial benchmarks are now removed, and we allow
the consumer of the snark-utils library to choose if they want to use
parallel iterators for i/o via a feature flag