### PR TITLE
Simplify IO

### DIFF
--- a/phase2/tests/mpc.rs
+++ b/phase2/tests/mpc.rs
@@ -38,7 +38,8 @@ where
 
     // read the transcript
     let mut mpc =
-        MPCParameters::<E>::new_from_buffer(c, (&transcript, compressed), phase2_size).unwrap();
+        MPCParameters::<E>::new_from_buffer(c, &mut &transcript[..], compressed, phase2_size)
+            .unwrap();
 
     let before = mpc.clone();
     // it is _not_ safe to use it yet, there must be 1 contribution

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -26,7 +26,7 @@ hex-literal = "0.1.4"
 
 [dev-dependencies]
 criterion = "0.3"
-zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", version = "0.1.0", features = ["parallel", "full"] }
+zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", version = "0.1.0", features = ["parallel", "full", "derive"] }
 test-helpers = { path = "../test-helpers" }
 
 [[bench]]

--- a/snark-utils/src/helpers.rs
+++ b/snark-utils/src/helpers.rs
@@ -1,5 +1,7 @@
-use crate::errors::{Error, VerificationError};
-use crate::{buffer_size, BatchSerializer, Result, UseCompression};
+use crate::{
+    errors::{Error, VerificationError},
+    Result,
+};
 use blake2::{digest::generic_array::GenericArray, Blake2b, Digest};
 use crypto::digest::Digest as CryptoDigest;
 use crypto::sha2::Sha256;
@@ -19,18 +21,6 @@ use zexe_algebra::{
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use zexe_fft::{cfg_into_iter, cfg_iter, cfg_iter_mut};
-
-pub fn write_elements<C: AffineCurve, W: Write>(
-    writer: &mut W,
-    elements: &[C],
-    compression: UseCompression,
-) -> Result<()> {
-    // we want to write to the buffer in parallel, so we'll have to allocate here to [u8]
-    let mut buf = vec![0; elements.len() * buffer_size::<C>(compression)];
-    buf.write_batch(&elements, compression)?;
-    writer.write_all(&buf)?;
-    Ok(())
-}
 
 /// Generate the powers by raising the key's `tau` to all powers
 /// belonging to this chunk

--- a/snark-utils/src/io/read.rs
+++ b/snark-utils/src/io/read.rs
@@ -11,6 +11,15 @@ pub trait Deserializer {
     /// Reads 1 compressed or uncompressed element
     fn read_element<G: AffineCurve>(&mut self, compression: UseCompression) -> Result<G>;
 
+    /// Reads exact number of elements
+    fn read_elements_exact<G: AffineCurve>(
+        &mut self,
+        num: usize,
+        compression: UseCompression,
+    ) -> Result<Vec<G>> {
+        (0..num).map(|_| self.read_element(compression)).collect()
+    }
+
     /// Reads 1 compressed or uncompressed element to a pre-allocated element
     fn read_element_preallocated<G: AffineCurve>(
         &mut self,
@@ -19,7 +28,6 @@ pub trait Deserializer {
     ) -> Result<()>;
 }
 
-// TODO: Implement this for `Read`
 pub trait BatchDeserializer {
     /// Reads multiple elements from the buffer
     fn read_batch<G: AffineCurve>(&self, compression: UseCompression) -> Result<Vec<G>>;

--- a/snark-utils/src/io/write.rs
+++ b/snark-utils/src/io/write.rs
@@ -15,9 +15,20 @@ pub trait Serializer {
         element: &impl AffineCurve,
         compression: UseCompression,
     ) -> Result<()>;
+
+    /// Writes a list of elements serially
+    fn write_elements_exact<G: AffineCurve>(
+        &mut self,
+        elements: &[G],
+        compression: UseCompression,
+    ) -> Result<()> {
+        elements
+            .iter()
+            .map(|el| self.write_element(el, compression))
+            .collect()
+    }
 }
 
-// TODO: Implement this for `Write`
 pub trait BatchSerializer {
     /// Initializes the buffer with the provided element
     fn init_element<G: AffineCurve>(


### PR DESCRIPTION
The recent IO changes in the underlying methods allow us to remove a bunch of code and finally generalize our functions to use Readers/Writers instead of slices.