### PR TITLE
Use Phase2 with subset of lagrange coefficients

### DIFF
--- a/bls-snark-setup/src/cli/new.rs
+++ b/bls-snark-setup/src/cli/new.rs
@@ -15,6 +15,10 @@ pub struct NewOpts {
     help: bool,
     #[options(help = "the path to the phase1 parameters", default = "phase1")]
     pub phase1: String,
+    #[options(
+        help = "the total number of coefficients (in powers of 2) which were created after processing phase 1"
+    )]
+    pub phase1_size: u32,
     #[options(help = "the challenge file name to be created", default = "challenge")]
     pub output: String,
     #[options(
@@ -77,7 +81,12 @@ pub fn new(opt: &NewOpts) -> Result<()> {
 
     // Read `num_constraints` Lagrange coefficients from the Phase1 Powers of Tau which were
     // prepared for this step. This will fail if Phase 1 was too small.
-    let phase1 = Groth16Params::<SW6>::read(&mut phase1_transcript, COMPRESSION, num_constraints)?;
+    let phase1 = Groth16Params::<SW6>::read(
+        &mut phase1_transcript,
+        COMPRESSION,
+        2usize.pow(opt.phase1_size),
+        num_constraints,
+    )?;
 
     // Convert it to a QAP
     let keypair = circuit_to_qap(valset)?;

--- a/e2e.sh
+++ b/e2e.sh
@@ -24,7 +24,7 @@ $phase2 --response-fname response --phase2-fname processed --phase2-size $POWER
 
 ###### Phase 2
 
-$snark new --phase1 processed --output ceremony --num-epochs $NUM_EPOCHS --num-validators $NUM_VALIDATORS
+$snark new --phase1 processed --output ceremony --num-epochs $NUM_EPOCHS --num-validators $NUM_VALIDATORS --phase1-size $POWER
 cp ceremony initial
 $snark contribute --data ceremony
 $snark contribute --data ceremony

--- a/snark-utils/src/groth16_utils.rs
+++ b/snark-utils/src/groth16_utils.rs
@@ -202,18 +202,18 @@ mod tests {
 
     #[test]
     fn first_half_powers() {
-        let power = 3 as usize;
-        let phase2_size = 2u32.pow(power as u32) as usize / 2;
-        read_write_curve::<Bls12_377>(power, phase2_size, UseCompression::Yes);
-        read_write_curve::<Bls12_377>(power, phase2_size, UseCompression::No);
+        let power = 4 as usize;
+        let prepared_phase1_size = 2u32.pow(power as u32) as usize / 2;
+        read_write_curve::<Bls12_377>(power, prepared_phase1_size, UseCompression::Yes);
+        read_write_curve::<Bls12_377>(power, prepared_phase1_size, UseCompression::No);
     }
 
     #[test]
     fn phase2_equal_to_powers() {
         let power = 3 as usize;
-        let phase2_size = 2u32.pow(power as u32) as usize;
-        read_write_curve::<Bls12_377>(power, phase2_size, UseCompression::Yes);
-        read_write_curve::<Bls12_377>(power, phase2_size, UseCompression::No);
+        let prepared_phase1_size = 2u32.pow(power as u32) as usize;
+        read_write_curve::<Bls12_377>(power, prepared_phase1_size, UseCompression::Yes);
+        read_write_curve::<Bls12_377>(power, prepared_phase1_size, UseCompression::No);
     }
 
     #[test]
@@ -230,7 +230,7 @@ mod tests {
 
     fn read_write_curve<E: PairingEngine>(
         powers: usize,
-        phase2_size: usize,
+        prepared_phase1_size: usize,
         compressed: UseCompression,
     ) {
         let batch = 2;
@@ -239,7 +239,7 @@ mod tests {
         let accumulator = BatchedAccumulator::deserialize(&output, compressed, &params).unwrap();
 
         let groth_params = Groth16Params::<E>::new(
-            phase2_size,
+            prepared_phase1_size,
             accumulator.tau_powers_g1,
             accumulator.tau_powers_g2,
             accumulator.alpha_tau_powers_g1,
@@ -249,11 +249,45 @@ mod tests {
 
         let mut writer = vec![];
         groth_params.write(&mut writer, compat(compressed)).unwrap();
-        let mut reader = vec![0; writer.len()];
-        reader.copy_from_slice(&writer);
-        let deserialized =
-            Groth16Params::<E>::read(&mut &reader[..], compat(compressed), phase2_size).unwrap();
+        let mut reader = std::io::Cursor::new(writer);
+        let deserialized = Groth16Params::<E>::read(
+            &mut reader,
+            compat(compressed),
+            prepared_phase1_size,
+            prepared_phase1_size, // phase2_size == prepared phase1 size
+        )
+        .unwrap();
+        reader.set_position(0);
         assert_eq!(deserialized, groth_params);
+
+        let subset = prepared_phase1_size / 2;
+        let deserialized_subset = Groth16Params::<E>::read(
+            &mut reader,
+            compat(compressed),
+            prepared_phase1_size,
+            subset, // phase2 size is smaller than the prepared phase1 size
+        )
+        .unwrap();
+        assert_eq!(
+            &deserialized_subset.coeffs_g1[..],
+            &groth_params.coeffs_g1[..subset]
+        );
+        assert_eq!(
+            &deserialized_subset.coeffs_g2[..],
+            &groth_params.coeffs_g2[..subset]
+        );
+        assert_eq!(
+            &deserialized_subset.alpha_coeffs_g1[..],
+            &groth_params.alpha_coeffs_g1[..subset]
+        );
+        assert_eq!(
+            &deserialized_subset.beta_coeffs_g1[..],
+            &groth_params.beta_coeffs_g1[..subset]
+        );
+        assert_eq!(
+            &deserialized_subset.h_g1[..],
+            &groth_params.h_g1[..subset - 1]
+        ); // h_query is 1 less element
     }
 
     // helper


### PR DESCRIPTION
Previously, the Phase2 MPC implementation required that `phase2_size` was equal to the size used when Groth16Params was created (i.e. the one used in `prepare_phase2`. This means that we'd need to re-run `prepare_phase2.rs` _for all_ circuit sizes we'd need. This is impractical, given our circuit sizes and curve choice.

We now allow providing a `phase1_size` which will allow pulling fewer coefficients, enabling more flexible Phase 2 ceremonies without having to re-run the prepare_phase2 code multiple times.

----

It should be noted that this was "kind of" not an issue in the original repository, because `prepare_phase2.rs` would run (redundantly) for multiple potential circuit sizes