### PR TITLE
fix: fix phase 2 size calculation

### DIFF
--- a/bls-snark-setup/src/cli/new.rs
+++ b/bls-snark-setup/src/cli/new.rs
@@ -53,7 +53,7 @@ pub fn empty_circuit(opt: &NewOpts) -> (ValidatorSetUpdate<Bls12_377>, usize) {
             .clone()
             .generate_constraints(&mut counter)
             .expect("could not calculate number of required constraints");
-        let phase2_size = counter.num_aux + counter.num_inputs + counter.num_constraints;
+        let phase2_size = std::cmp::max(counter.num_constraints, counter.num_aux + counter.num_inputs + 1);
         let power = log_2(phase2_size) as u32;
         // get the nearest power of 2
         if phase2_size < 2usize.pow(power) {

--- a/bls-snark-setup/src/cli/new.rs
+++ b/bls-snark-setup/src/cli/new.rs
@@ -53,7 +53,10 @@ pub fn empty_circuit(opt: &NewOpts) -> (ValidatorSetUpdate<Bls12_377>, usize) {
             .clone()
             .generate_constraints(&mut counter)
             .expect("could not calculate number of required constraints");
-        let phase2_size = std::cmp::max(counter.num_constraints, counter.num_aux + counter.num_inputs + 1);
+        let phase2_size = std::cmp::max(
+            counter.num_constraints,
+            counter.num_aux + counter.num_inputs + 1,
+        );
         let power = log_2(phase2_size) as u32;
         // get the nearest power of 2
         if phase2_size < 2usize.pow(power) {

--- a/phase2/tests/mpc.rs
+++ b/phase2/tests/mpc.rs
@@ -38,7 +38,7 @@ where
     // perform the MPC on only the amount of constraints required for the circuit
     let mut counter = zexe_r1cs_std::test_constraint_counter::ConstraintCounter::new();
     c.clone().generate_constraints(&mut counter).unwrap();
-    let phase2_size = counter.num_aux + counter.num_inputs + counter.num_constraints;
+    let phase2_size = std::cmp::max(counter.num_constraints, counter.num_aux + counter.num_inputs + 1);
 
     let mut mpc =
         MPCParameters::<E>::new_from_buffer(c, writer.as_mut(), compressed, 32, phase2_size)

--- a/phase2/tests/mpc.rs
+++ b/phase2/tests/mpc.rs
@@ -38,7 +38,10 @@ where
     // perform the MPC on only the amount of constraints required for the circuit
     let mut counter = zexe_r1cs_std::test_constraint_counter::ConstraintCounter::new();
     c.clone().generate_constraints(&mut counter).unwrap();
-    let phase2_size = std::cmp::max(counter.num_constraints, counter.num_aux + counter.num_inputs + 1);
+    let phase2_size = std::cmp::max(
+        counter.num_constraints,
+        counter.num_aux + counter.num_inputs + 1,
+    );
 
     let mut mpc =
         MPCParameters::<E>::new_from_buffer(c, writer.as_mut(), compressed, 32, phase2_size)


### PR DESCRIPTION
Fixes phase 2 size calculation - some circuits have more variables than constraints, and so taking powers from the "prepare phase 2" step based on the number of constraints is not enough.