### PR TITLE
feat: implement working in chunks for Phase 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
          name: Test chunked powers of tau
          command: bash ./powers_of_tau_chunked.sh
       - run:
+         name: Test full powers of tau
+         command: bash ./powers_of_tau_full.sh
+      - run:
           name: Check Style
           command: |
             cargo fmt --all -- --check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
       - run:
           name: Test
           command: cargo test --all --all-features
+       - run:
+         name: Test chunked powers of tau
+         command: ./powers_of_tau_chunked.sh
       - run:
           name: Check Style
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: cargo test --all --all-features
       - run:
          name: Test chunked powers of tau
-         command: ./powers_of_tau_chunked.sh
+         command: bash ./powers_of_tau_chunked.sh
       - run:
           name: Check Style
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Test
           command: cargo test --all --all-features
-       - run:
+      - run:
          name: Test chunked powers of tau
          command: ./powers_of_tau_chunked.sh
       - run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core",
 ]
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "algebra-core"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core-derive",
  "derivative",
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 name = "algebra-core-derive"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -98,7 +98,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "bench-utils"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 
 [[package]]
 name = "bitflags"
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 name = "bls-crypto"
 version = "0.1.4"
-source = "git+https://github.com/celo-org/celo-bls-snark-rs#f5addeecd7b40af584344c3dd799d22c87848de3"
+source = "git+https://github.com/celo-org/celo-bls-snark-rs?branch=kobigurk/update_zexe#e3e1f1bb78e8de929e040ac7f123baa8f9046e5a"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "bls-gadgets"
 version = "0.1.4"
-source = "git+https://github.com/celo-org/celo-bls-snark-rs#f5addeecd7b40af584344c3dd799d22c87848de3"
+source = "git+https://github.com/celo-org/celo-bls-snark-rs?branch=kobigurk/update_zexe#e3e1f1bb78e8de929e040ac7f123baa8f9046e5a"
 dependencies = [
  "algebra",
  "bls-crypto",
@@ -261,7 +261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
 dependencies = [
  "const-random-macro",
- "proc-macro-hack 0.5.16",
+ "proc-macro-hack 0.5.18",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 dependencies = [
  "getrandom",
- "proc-macro-hack 0.5.16",
+ "proc-macro-hack 0.5.18",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "crypto-primitives"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core",
  "bench-utils",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "epoch-snark"
 version = "0.1.4"
-source = "git+https://github.com/celo-org/celo-bls-snark-rs#f5addeecd7b40af584344c3dd799d22c87848de3"
+source = "git+https://github.com/celo-org/celo-bls-snark-rs?branch=kobigurk/update_zexe#e3e1f1bb78e8de929e040ac7f123baa8f9046e5a"
 dependencies = [
  "algebra",
  "blake2s_simd",
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "ff-fft"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core",
  "rand 0.7.3",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "field-assembly"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "mince",
 ]
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "gm17"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core",
  "bench-utils",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "groth16"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core",
  "bench-utils",
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "mince"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "quote 1.0.7",
  "syn 1.0.33",
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "oorandom"
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-hack-impl"
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra-core",
  "smallvec",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "r1cs-std"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#bf566aa37d3a97fd14101c337bd4c49fea3b575d"
+source = "git+https://github.com/scipr-lab/zexe?rev=38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1#38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1"
 dependencies = [
  "algebra",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,6 @@ dependencies = [
  "criterion",
  "gumdrop",
  "hex 0.4.2",
- "hex-literal",
  "itertools 0.8.2",
  "memmap",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "algebra",
  "criterion",
  "gumdrop",
+ "hex 0.4.2",
  "hex-literal",
  "itertools 0.8.2",
  "memmap",
@@ -1222,6 +1223,7 @@ version = "0.1.0"
 dependencies = [
  "algebra",
  "blake2",
+ "blake2s_simd",
  "criterion",
  "crossbeam",
  "ff-fft",

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
+
+POWER=27
+BATCH=2097152
+CURVE="bw6"
+SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+
+powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --seed $SEED"
+phase2="cargo run --release --bin prepare_phase2 -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
+snark="cargo run --release --bin bls-snark-setup --"
+
+$powersoftau --chunk-index 0 new --challenge-fname challenge_0
+time yes | $powersoftau --chunk-index 0 contribute --challenge-fname challenge_0 --response-fname response_0
+
+rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*

--- a/bls-snark-setup/Cargo.toml
+++ b/bls-snark-setup/Cargo.toml
@@ -10,10 +10,10 @@ description = "MPC for the Celo SNARK"
 phase2 = { path = "../phase2" }
 snark-utils = { path = "../snark-utils" }
 
-bls-snark = { package = "epoch-snark", git = "https://github.com/celo-org/celo-bls-snark-rs" }
-zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", version = "0.1.0", features = ["parallel", "full"] }
-zexe_r1cs_std = { package = "r1cs-std", git = "https://github.com/scipr-lab/zexe", version = "0.1.0" }
-zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", version = "0.1.0" }
+bls-snark = { package = "epoch-snark", git = "https://github.com/celo-org/celo-bls-snark-rs", branch = "kobigurk/update_zexe" }
+zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel", "full"] }
+zexe_r1cs_std = { package = "r1cs-std", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1" }
+zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1" }
 
 gumdrop = "0.7.0"
 hex-literal = "0.1.4"

--- a/bls-snark-setup/src/cli/new.rs
+++ b/bls-snark-setup/src/cli/new.rs
@@ -6,7 +6,7 @@ use zexe_r1cs_core::ConstraintSynthesizer;
 use zexe_r1cs_std::test_constraint_counter::ConstraintCounter;
 
 use phase2::parameters::{circuit_to_qap, MPCParameters};
-use snark_utils::{log_2, Groth16Params, Result, UseCompression};
+use snark_utils::{log_2, CheckForCorrectness, Groth16Params, Result, UseCompression};
 
 use memmap::MmapOptions;
 use std::fs::OpenOptions;
@@ -94,6 +94,7 @@ pub fn new(opt: &NewOpts) -> Result<()> {
     let phase1 = Groth16Params::<BW6_761>::read(
         &mut phase1_transcript,
         COMPRESSION,
+        CheckForCorrectness::No, // No need to check for correctness, since this has been processed by the coordinator.
         2usize.pow(opt.phase1_size),
         phase2_size,
     )?;

--- a/phase2/Cargo.toml
+++ b/phase2/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 snark-utils = { path = "../snark-utils" }
-zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", version = "0.1.0", features = ["parallel", "full"] }
-zexe_groth16 = { git = "https://github.com/scipr-lab/zexe", package = "groth16", version = "0.1.0", features = ["parallel"] }
-zexe_r1cs_core = { git = "https://github.com/scipr-lab/zexe", package = "r1cs-core", version = "0.1.0" }
+zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel", "full"] }
+zexe_groth16 = { git = "https://github.com/scipr-lab/zexe", package = "groth16", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel"] }
+zexe_r1cs_core = { git = "https://github.com/scipr-lab/zexe", package = "r1cs-core", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1" }
 
 
 rand = "0.7.3"
@@ -30,5 +30,5 @@ tracing = "0.1.13"
 [dev-dependencies]
 powersoftau = { path = "../powersoftau" }
 test-helpers = { path = "../test-helpers" }
-zexe_r1cs_std = { git = "https://github.com/scipr-lab/zexe", package = "r1cs-std", version = "0.1.0" }
+zexe_r1cs_std = { git = "https://github.com/scipr-lab/zexe", package = "r1cs-std", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1" }
 tracing-subscriber = "0.2.3"

--- a/phase2/src/keypair.rs
+++ b/phase2/src/keypair.rs
@@ -4,7 +4,9 @@
 //! Dispose of the private key ASAP once it's been used.
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use rand::Rng;
-use snark_utils::{hash_to_g2, Deserializer, HashWriter, Result, Serializer, UseCompression};
+use snark_utils::{
+    hash_to_g2, CheckForCorrectness, Deserializer, HashWriter, Result, Serializer, UseCompression,
+};
 use std::fmt;
 use std::io::{self, Read, Write};
 use zexe_algebra::{
@@ -89,10 +91,10 @@ impl<E: PairingEngine> PublicKey<E> {
     /// Reads the key's **uncompressed** points from the provided
     /// reader
     pub fn read<R: Read>(reader: &mut R) -> Result<PublicKey<E>> {
-        let delta_after = reader.read_element(UseCompression::No)?;
-        let s = reader.read_element(UseCompression::No)?;
-        let s_delta = reader.read_element(UseCompression::No)?;
-        let r_delta = reader.read_element(UseCompression::No)?;
+        let delta_after = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+        let s = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+        let s_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+        let r_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
         let mut transcript = [0u8; 64];
         reader.read_exact(&mut transcript)?;
 

--- a/phase2/src/keypair.rs
+++ b/phase2/src/keypair.rs
@@ -56,19 +56,19 @@ impl<E: PairingEngine> PublicKey<E> {
         response
     }
 
-    pub fn write_batch<W: Write>(writer: &mut W, pubkeys: &[PublicKey<E>]) -> Result<()> {
+    pub fn write_batch<W: Write>(mut writer: W, pubkeys: &[PublicKey<E>]) -> Result<()> {
         writer.write_u32::<BigEndian>(pubkeys.len() as u32)?;
         for pubkey in pubkeys {
-            pubkey.write(writer)?;
+            pubkey.write(&mut writer)?;
         }
         Ok(())
     }
 
-    pub fn read_batch<R: Read>(reader: &mut R) -> Result<Vec<Self>> {
+    pub fn read_batch<R: Read>(mut reader: R) -> Result<Vec<Self>> {
         let mut contributions = vec![];
         let contributions_len = reader.read_u32::<BigEndian>()? as usize;
         for _ in 0..contributions_len {
-            contributions.push(PublicKey::read(reader)?);
+            contributions.push(PublicKey::read(&mut reader)?);
         }
         Ok(contributions)
     }
@@ -79,22 +79,22 @@ impl<E: PairingEngine> PublicKey<E> {
 
     /// Serializes the key's **uncompressed** points to the provided
     /// writer
-    pub fn write<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.delta_after.serialize_uncompressed(writer)?;
-        self.s.serialize_uncompressed(writer)?;
-        self.s_delta.serialize_uncompressed(writer)?;
-        self.r_delta.serialize_uncompressed(writer)?;
+    pub fn write<W: Write>(&self, mut writer: W) -> Result<()> {
+        self.delta_after.serialize_uncompressed(&mut writer)?;
+        self.s.serialize_uncompressed(&mut writer)?;
+        self.s_delta.serialize_uncompressed(&mut writer)?;
+        self.r_delta.serialize_uncompressed(&mut writer)?;
         writer.write_all(&self.transcript)?;
         Ok(())
     }
 
     /// Reads the key's **uncompressed** points from the provided
     /// reader
-    pub fn read<R: Read>(reader: &mut R) -> Result<PublicKey<E>> {
-        let delta_after = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
-        let s = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
-        let s_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
-        let r_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+    pub fn read<R: Read>(mut reader: R) -> Result<PublicKey<E>> {
+        let delta_after = reader.read_element(UseCompression::No, CheckForCorrectness::Both)?;
+        let s = reader.read_element(UseCompression::No, CheckForCorrectness::Both)?;
+        let s_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Both)?;
+        let r_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Both)?;
         let mut transcript = [0u8; 64];
         reader.read_exact(&mut transcript)?;
 

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -279,10 +279,10 @@ impl<E: PairingEngine> MPCParameters<E> {
 
     /// Serialize these parameters. The serialized parameters
     /// can be read by Zexe's Groth16 `Parameters`.
-    pub fn write<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.params.serialize(writer)?;
+    pub fn write<W: Write>(&self, mut writer: W) -> Result<()> {
+        self.params.serialize(&mut writer)?;
         writer.write_all(&self.cs_hash)?;
-        PublicKey::write_batch(writer, &self.contributions)?;
+        PublicKey::write_batch(&mut writer, &self.contributions)?;
 
         Ok(())
     }

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -550,7 +550,7 @@ mod tests {
         let powers = 5;
         let batch = 16;
         let phase2_size = 7;
-        let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
+        let params = CeremonyParams::<E>::new_full(powers, batch);
         let accumulator = {
             let compressed = UseCompression::No;
             let (_, output, _, _) = setup_verify(compressed, compressed, &params);

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -48,6 +48,7 @@ impl<E: PairingEngine> MPCParameters<E> {
         circuit: C,
         transcript: &mut [u8],
         compressed: UseCompression,
+        check_input_for_correctness: CheckForCorrectness,
         phase1_size: usize,
         phase2_size: usize,
     ) -> Result<MPCParameters<E>>
@@ -55,7 +56,13 @@ impl<E: PairingEngine> MPCParameters<E> {
         C: ConstraintSynthesizer<E::Fr>,
     {
         let assembly = circuit_to_qap::<E, _>(circuit)?;
-        let params = Groth16Params::<E>::read(transcript, compressed, phase1_size, phase2_size)?;
+        let params = Groth16Params::<E>::read(
+            transcript,
+            compressed,
+            check_input_for_correctness,
+            phase1_size,
+            phase2_size,
+        )?;
         Self::new(assembly, params)
     }
 

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -554,7 +554,8 @@ mod tests {
         let accumulator = {
             let compressed = UseCompression::No;
             let (_, output, _, _) = setup_verify(compressed, compressed, &params);
-            BatchedAccumulator::deserialize(&output, compressed, &params).unwrap()
+            BatchedAccumulator::deserialize(&output, compressed, CheckForCorrectness::No, &params)
+                .unwrap()
         };
 
         let groth_params = Groth16Params::<E>::new(

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -543,7 +543,7 @@ mod tests {
         let powers = 5;
         let batch = 16;
         let phase2_size = 7;
-        let params = CeremonyParams::<E>::new(powers, batch);
+        let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
         let accumulator = {
             let compressed = UseCompression::No;
             let (_, output, _, _) = setup_verify(compressed, compressed, &params);

--- a/phase2/tests/mpc.rs
+++ b/phase2/tests/mpc.rs
@@ -15,7 +15,7 @@ where
 {
     let powers = 6; // powers of tau
     let batch = ((1 << powers) << 1) - 1;
-    let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
+    let params = CeremonyParams::<E>::new_full(powers, batch);
     let compressed = UseCompression::Yes;
     // make 1 power of tau contribution (assume powers of tau gets calculated properly)
     let (_, output, _, _) = setup_verify(compressed, compressed, &params);

--- a/phase2/tests/mpc.rs
+++ b/phase2/tests/mpc.rs
@@ -14,7 +14,7 @@ where
     C: Clone + ConstraintSynthesizer<E::Fr>,
 {
     let powers = 6; // powers of tau
-    let batch = 4;
+    let batch = ((1 << powers) << 1) - 1;
     let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
     let compressed = UseCompression::Yes;
     // make 1 power of tau contribution (assume powers of tau gets calculated properly)

--- a/phase2/tests/mpc.rs
+++ b/phase2/tests/mpc.rs
@@ -15,7 +15,7 @@ where
 {
     let powers = 6; // powers of tau
     let batch = 4;
-    let params = CeremonyParams::<E>::new(powers, batch);
+    let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
     let compressed = UseCompression::Yes;
     // make 1 power of tau contribution (assume powers of tau gets calculated properly)
     let (_, output, _, _) = setup_verify(compressed, compressed, &params);

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -3,24 +3,23 @@
 rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
 
 POWER=10
-BATCH=128
-MAX_CHUNK_INDEX=15 # we have 16 chunks, since we have a total of 2^11-1 powers
+BATCH=64
+CHUNK_SIZE=512
+MAX_CHUNK_INDEX=3 # we have 16 chunks, since we have a total of 2^11-1 powers
 CURVE="bw6"
 SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
 
-powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --seed $SEED"
-phase2="cargo run --release --bin prepare_phase2 -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
-snark="cargo run --release --bin bls-snark-setup --"
+powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED"
 
 ####### Phase 1
 
 for i in $(seq 0 $MAX_CHUNK_INDEX); do
   $powersoftau --chunk-index $i new --challenge-fname challenge_$i
   yes | $powersoftau --chunk-index $i contribute --challenge-fname challenge_$i --response-fname response_$i
-  $powersoftau  --chunk-index $i verify-and-transform-chunk --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
+  $powersoftau  --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
   rm challenge_$i # no longer needed
   echo response_$i >> response_list
 done
 
 $powersoftau combine --response-list-fname response_list --combined-fname combined
-$powersoftau verify-and-transform-full --response-fname combined
+$powersoftau verify-and-transform-ratios --response-fname combined

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm -f challenge* response* new_challenge* new_response* new_new_challenge_* processed* initial_ceremony* response_list* combined*
+rm -f challenge* response* new_challenge* new_response* new_new_challenge_* processed* initial_ceremony* response_list* combined* seed*
 
 POWER=10
 BATCH=64
@@ -8,10 +8,12 @@ CHUNK_SIZE=512
 MAX_CHUNK_INDEX=3 # we have 16 chunks, since we have a total of 2^11-1 powers
 CURVE="bw6"
 SEED1=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+echo $SEED1 > seed1
 SEED2=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+echo $SEED2 > seed2
 
-powersoftau_1="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED1"
-powersoftau_2="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED2"
+powersoftau_1="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed seed1"
+powersoftau_2="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed seed2"
 powersoftau_combine="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER"
 powersoftau_full="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER"
 

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
+
+POWER=10
+NUM_VALIDATORS=100
+NUM_EPOCHS=30
+BATCH=128
+MAX_CHUNK_INDEX=15 # we have 16 chunks, since we have a total of 2^11-1 powers
+CURVE="bw6"
+SEED=`hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random`
+
+powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --seed $SEED"
+phase2="cargo run --release --bin prepare_phase2 -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
+snark="cargo run --release --bin bls-snark-setup --"
+
+####### Phase 1
+
+for i in $(seq 0 $MAX_CHUNK_INDEX); do
+  $powersoftau --chunk-index $i new --challenge-fname challenge_$i
+  yes | $powersoftau --chunk-index $i contribute --challenge-fname challenge_$i --response-fname response_$i
+  $powersoftau  --chunk-index $i verify-and-transform-chunk --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
+  rm challenge_$i # no longer needed
+  echo response_$i >> response_list
+done
+
+$powersoftau combine --response-list-fname response_list --combined-fname combined
+$powersoftau verify-and-transform-full --response-fname combined

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -8,7 +8,7 @@ NUM_EPOCHS=30
 BATCH=128
 MAX_CHUNK_INDEX=15 # we have 16 chunks, since we have a total of 2^11-1 powers
 CURVE="bw6"
-SEED=`hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random`
+SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
 
 powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --seed $SEED"
 phase2="cargo run --release --bin prepare_phase2 -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -1,28 +1,43 @@
 #!/bin/bash
 
-rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
+rm -f challenge* response* new_challenge* new_response* new_new_challenge_* processed* initial_ceremony* response_list* combined*
 
 POWER=10
 BATCH=64
 CHUNK_SIZE=512
 MAX_CHUNK_INDEX=3 # we have 16 chunks, since we have a total of 2^11-1 powers
 CURVE="bw6"
-SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+SEED1=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+SEED2=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
 
-powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED"
-powersoftau_full="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed $SEED"
+powersoftau_1="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED1"
+powersoftau_2="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED2"
+powersoftau_combine="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER"
+powersoftau_full="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER"
 
 ####### Phase 1
 
-for i in $(seq 0 $MAX_CHUNK_INDEX); do
-  $powersoftau --chunk-index $i new --challenge-fname challenge_$i
-  yes | $powersoftau --chunk-index $i contribute --challenge-fname challenge_$i --response-fname response_$i
-  $powersoftau --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
-  rm challenge_$i new_challenge_$i # no longer needed
-  echo response_$i >> response_list
+for i in $(seq 0 $(($MAX_CHUNK_INDEX/2))); do
+  $powersoftau_1 --chunk-index $i new --challenge-fname challenge_$i
+  yes | $powersoftau_1 --chunk-index $i contribute --challenge-fname challenge_$i --response-fname response_$i
+  $powersoftau_1 --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
+  yes | $powersoftau_2 --chunk-index $i contribute --challenge-fname new_challenge_$i --response-fname new_response_$i
+  $powersoftau_2 --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname new_challenge_$i --response-fname new_response_$i --new-challenge-fname new_new_challenge_$i
+  rm challenge_$i new_challenge_$i new_new_challenge_$i # no longer needed
+  echo new_response_$i >> response_list
 done
 
-$powersoftau combine --response-list-fname response_list --combined-fname combined
+for i in $(seq $(($MAX_CHUNK_INDEX/2 + 1)) $MAX_CHUNK_INDEX); do
+  $powersoftau_1 --chunk-index $i new --challenge-fname challenge_$i
+  yes | $powersoftau_2 --chunk-index $i contribute --challenge-fname challenge_$i --response-fname response_$i
+  $powersoftau_1 --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
+  yes | $powersoftau_1 --chunk-index $i contribute --challenge-fname new_challenge_$i --response-fname new_response_$i
+  $powersoftau_2 --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname new_challenge_$i --response-fname new_response_$i --new-challenge-fname new_new_challenge_$i
+  rm challenge_$i new_challenge_$i new_new_challenge_$i # no longer needed
+  echo new_response_$i >> response_list
+done
+
+$powersoftau_combine combine --response-list-fname response_list --combined-fname combined
 $powersoftau_full beacon --challenge-fname combined --response-fname response_beacon --beacon-hash 0000000000000000000a558a61ddc8ee4e488d647a747fe4dcc362fe2026c620
 $powersoftau_full verify-and-transform-pok-and-correctness --challenge-fname combined --response-fname response_beacon --new-challenge-fname response_beacon_new_challenge
-$powersoftau verify-and-transform-ratios --response-fname response_beacon_new_challenge
+$powersoftau_full verify-and-transform-ratios --response-fname response_beacon_new_challenge

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -10,16 +10,19 @@ CURVE="bw6"
 SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
 
 powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode chunked --chunk-size $CHUNK_SIZE --power $POWER --seed $SEED"
+powersoftau_full="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed $SEED"
 
 ####### Phase 1
 
 for i in $(seq 0 $MAX_CHUNK_INDEX); do
   $powersoftau --chunk-index $i new --challenge-fname challenge_$i
   yes | $powersoftau --chunk-index $i contribute --challenge-fname challenge_$i --response-fname response_$i
-  $powersoftau  --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
-  rm challenge_$i # no longer needed
+  $powersoftau --chunk-index $i verify-and-transform-pok-and-correctness --challenge-fname challenge_$i --response-fname response_$i --new-challenge-fname new_challenge_$i
+  rm challenge_$i new_challenge_$i # no longer needed
   echo response_$i >> response_list
 done
 
 $powersoftau combine --response-list-fname response_list --combined-fname combined
-$powersoftau verify-and-transform-ratios --response-fname combined
+$powersoftau_full beacon --challenge-fname combined --response-fname response_beacon --beacon-hash 0000000000000000000a558a61ddc8ee4e488d647a747fe4dcc362fe2026c620
+$powersoftau_full verify-and-transform-pok-and-correctness --challenge-fname combined --response-fname response_beacon --new-challenge-fname response_beacon_new_challenge
+$powersoftau verify-and-transform-ratios --response-fname response_beacon_new_challenge

--- a/powers_of_tau_chunked.sh
+++ b/powers_of_tau_chunked.sh
@@ -3,8 +3,6 @@
 rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
 
 POWER=10
-NUM_VALIDATORS=100
-NUM_EPOCHS=30
 BATCH=128
 MAX_CHUNK_INDEX=15 # we have 16 chunks, since we have a total of 2^11-1 powers
 CURVE="bw6"

--- a/powers_of_tau_full.sh
+++ b/powers_of_tau_full.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
+
+POWER=10
+BATCH=64
+MAX_CHUNK_INDEX=3 # we have 16 chunks, since we have a total of 2^11-1 powers
+CURVE="bw6"
+SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+
+powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed $SEED"
+
+####### Phase 1
+
+$powersoftau new --challenge-fname challenge
+yes | $powersoftau contribute --challenge-fname challenge --response-fname response
+$powersoftau verify-and-transform-pok-and-correctness --challenge-fname challenge --response-fname response --new-challenge-fname new_challenge
+$powersoftau verify-and-transform-ratios --response-fname new_challenge
+

--- a/powers_of_tau_full.sh
+++ b/powers_of_tau_full.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined*
+rm -f challenge* response* new_challenge* processed* initial_ceremony* response_list* combined* seed*
 
 POWER=10
 BATCH=64
 MAX_CHUNK_INDEX=3 # we have 16 chunks, since we have a total of 2^11-1 powers
 CURVE="bw6"
 SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+echo $SEED > seed1
 
-powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed $SEED"
+powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed seed1"
 
 ####### Phase 1
 

--- a/powers_of_tau_full.sh
+++ b/powers_of_tau_full.sh
@@ -15,5 +15,7 @@ powersoftau="cargo run --release --bin powersoftau -- --curve-kind $CURVE --batc
 $powersoftau new --challenge-fname challenge
 yes | $powersoftau contribute --challenge-fname challenge --response-fname response
 $powersoftau verify-and-transform-pok-and-correctness --challenge-fname challenge --response-fname response --new-challenge-fname new_challenge
-$powersoftau verify-and-transform-ratios --response-fname new_challenge
+$powersoftau beacon --challenge-fname new_challenge --response-fname new_response --beacon-hash 0000000000000000000a558a61ddc8ee4e488d647a747fe4dcc362fe2026c620
+$powersoftau verify-and-transform-pok-and-correctness --challenge-fname new_challenge --response-fname new_response --new-challenge-fname new_challenge_2
+$powersoftau verify-and-transform-ratios --response-fname new_challenge_2
 

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -12,8 +12,7 @@ repository = "https://github.com/matter-labs/powersoftau"
 
 [dependencies]
 snark-utils = { path = "../snark-utils", features = ["parallel"] }
-
-zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", version = "0.1.0", features = ["parallel", "bw6_761"] }
+zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel", "bw6_761"] }
 
 rand = { version = "0.7" }
 memmap = "0.7.0"
@@ -29,7 +28,7 @@ hex = "0.4.2"
 
 [dev-dependencies]
 criterion = "0.3"
-zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", version = "0.1.0", features = ["parallel", "full", "derive"] }
+zexe_algebra = { git = "https://github.com/scipr-lab/zexe", package = "algebra", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel", "full", "derive"] }
 test-helpers = { path = "../test-helpers" }
 
 [[bench]]

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -21,7 +21,6 @@ rayon = "1.3.0"
 
 # used for the CLIs
 gumdrop = "0.7.0"
-hex-literal = "0.1.4"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.3"
 hex = "0.4.2"

--- a/powersoftau/Cargo.toml
+++ b/powersoftau/Cargo.toml
@@ -25,6 +25,7 @@ gumdrop = "0.7.0"
 hex-literal = "0.1.4"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.3"
+hex = "0.4.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/powersoftau/benches/accumulator.rs
+++ b/powersoftau/benches/accumulator.rs
@@ -58,7 +58,7 @@ fn contribute_benchmark(c: &mut Criterion) {
                         &mut output,
                         in_compressed,
                         out_compressed,
-                        CheckForCorrectness::Yes,
+                        CheckForCorrectness::Both,
                         &privkey,
                         &parameters,
                     )
@@ -101,7 +101,7 @@ fn verify_benchmark(c: &mut Criterion) {
                 &power,
                 |b, _power| {
                     b.iter(|| {
-                        RawAccumulator::verify_transformation_chunk(
+                        RawAccumulator::verify_transformation_pok_and_correctness(
                             &input,
                             &output,
                             &pubkey,

--- a/powersoftau/benches/accumulator.rs
+++ b/powersoftau/benches/accumulator.rs
@@ -16,7 +16,7 @@ fn generate_initial_benchmark(c: &mut Criterion) {
             if power > 8 {
                 group.sample_size(10);
             }
-            let parameters = CeremonyParams::<Bls12_377>::new_for_first_chunk(power, power);
+            let parameters = CeremonyParams::<Bls12_377>::new_full(power, power);
             let expected_challenge_length = parameters.get_length(*compression);
 
             // count in `other` powers (G1 will be 2x that)
@@ -39,7 +39,7 @@ fn contribute_benchmark(c: &mut Criterion) {
 
     // we gather data on various sizes
     for size in 4..8 {
-        let parameters = CeremonyParams::<Bls12_377>::new_for_first_chunk(size, batch);
+        let parameters = CeremonyParams::<Bls12_377>::new_full(size, batch);
         let (input, _) = generate_input(&parameters, in_compressed);
         let mut output = vec![0; parameters.get_length(out_compressed)];
         let current_accumulator_hash = blank_hash();
@@ -91,7 +91,7 @@ fn verify_benchmark(c: &mut Criterion) {
     // Test the benchmark for everything in the parameter space
     for power in powers {
         for (compressed_input, compressed_output) in compression {
-            let parameters = CeremonyParams::<Bls12_377>::new_for_first_chunk(power, batch);
+            let parameters = CeremonyParams::<Bls12_377>::new_full(power, batch);
 
             let (input, output, pubkey, current_accumulator_hash) =
                 setup_verify(*compressed_input, *compressed_output, &parameters);

--- a/powersoftau/benches/accumulator.rs
+++ b/powersoftau/benches/accumulator.rs
@@ -16,7 +16,7 @@ fn generate_initial_benchmark(c: &mut Criterion) {
             if power > 8 {
                 group.sample_size(10);
             }
-            let parameters = CeremonyParams::<Bls12_377>::new(power, power);
+            let parameters = CeremonyParams::<Bls12_377>::new_for_first_chunk(power, power);
             let expected_challenge_length = parameters.get_length(*compression);
 
             // count in `other` powers (G1 will be 2x that)
@@ -39,7 +39,7 @@ fn contribute_benchmark(c: &mut Criterion) {
 
     // we gather data on various sizes
     for size in 4..8 {
-        let parameters = CeremonyParams::<Bls12_377>::new(size, batch);
+        let parameters = CeremonyParams::<Bls12_377>::new_for_first_chunk(size, batch);
         let (input, _) = generate_input(&parameters, in_compressed);
         let mut output = vec![0; parameters.get_length(out_compressed)];
         let current_accumulator_hash = blank_hash();
@@ -91,7 +91,7 @@ fn verify_benchmark(c: &mut Criterion) {
     // Test the benchmark for everything in the parameter space
     for power in powers {
         for (compressed_input, compressed_output) in compression {
-            let parameters = CeremonyParams::<Bls12_377>::new(power, batch);
+            let parameters = CeremonyParams::<Bls12_377>::new_for_first_chunk(power, batch);
 
             let (input, output, pubkey, current_accumulator_hash) =
                 setup_verify(*compressed_input, *compressed_output, &parameters);

--- a/powersoftau/benches/accumulator.rs
+++ b/powersoftau/benches/accumulator.rs
@@ -101,7 +101,7 @@ fn verify_benchmark(c: &mut Criterion) {
                 &power,
                 |b, _power| {
                     b.iter(|| {
-                        RawAccumulator::verify_transformation(
+                        RawAccumulator::verify_transformation_chunk(
                             &input,
                             &output,
                             &pubkey,

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -98,7 +98,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
 
     /// Verifies a transformation of the `Accumulator` with the `PublicKey`, given a 64-byte transcript `digest`.
     #[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
-    pub fn verify_transformation_chunk_full(
+    pub fn verify_transformation_full(
         input: &[u8],
         output: &[u8],
         key: &PublicKey<E>,

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -126,8 +126,15 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
         compression: UseCompression,
         parameters: &'a CeremonyParams<E>,
     ) -> Result<BatchedAccumulator<'a, E>> {
-        let (tau_powers_g1, tau_powers_g2, alpha_tau_powers_g1, beta_tau_powers_g1, beta_g2, tau_single_g1, tau_single_g2) =
-            raw_accumulator::deserialize(input, compression, parameters)?;
+        let (
+            tau_powers_g1,
+            tau_powers_g2,
+            alpha_tau_powers_g1,
+            beta_tau_powers_g1,
+            beta_g2,
+            tau_single_g1,
+            tau_single_g2,
+        ) = raw_accumulator::deserialize(input, compression, parameters)?;
         Ok(BatchedAccumulator {
             tau_powers_g1,
             tau_powers_g2,
@@ -156,11 +163,11 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
 mod tests {
     use super::*;
     use rand::thread_rng;
-    use snark_utils::{batch_exp, calculate_hash, generate_powers_of_tau, derive_rng_from_seed};
+    use snark_utils::{batch_exp, calculate_hash, derive_rng_from_seed, generate_powers_of_tau};
     use test_helpers::{random_point, random_point_vec};
-    use zexe_algebra::{AffineCurve, Bls12_377, Bls12_381, ProjectiveCurve, BW6_761};
-    use tracing_subscriber::fmt::{Subscriber, time::ChronoUtc};
+    use tracing_subscriber::fmt::{time::ChronoUtc, Subscriber};
     use tracing_subscriber::EnvFilter;
+    use zexe_algebra::{AffineCurve, Bls12_377, Bls12_381, ProjectiveCurve, BW6_761};
 
     #[test]
     fn serialize_multiple_batches() {
@@ -310,7 +317,7 @@ mod tests {
     ) {
         let powers_length = 1 << powers;
         let powers_g1_length = (powers_length << 1) - 1;
-        let num_chunks = (powers_g1_length + batch - 1)/batch;
+        let num_chunks = (powers_g1_length + batch - 1) / batch;
 
         for chunk_index in 0..num_chunks {
             let parameters = CeremonyParams::<E>::new(powers, batch, chunk_index);
@@ -337,7 +344,7 @@ mod tests {
                 &privkey,
                 &parameters,
             )
-                .unwrap();
+            .unwrap();
             // ensure that the key is not available to the verifier
             drop(privkey);
 
@@ -374,7 +381,7 @@ mod tests {
                 &privkey,
                 &parameters,
             )
-                .unwrap();
+            .unwrap();
             // ensure that the key is not available to the verifier
             drop(privkey);
 

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -656,13 +656,15 @@ mod tests {
             .collect::<Vec<_>>();
         let parameters = CeremonyParams::<E>::new_full(powers, batch);
         let mut output = generate_output(&parameters, compressed_output);
-
+        let parameters =
+            CeremonyParams::<E>::new(ContributionMode::Chunked, 0, batch, powers, batch);
         combine(
             &chunks_participant_2,
             (&mut output, compressed_output),
             &parameters,
         )
         .unwrap();
+        let parameters = CeremonyParams::<E>::new_full(powers, batch);
         verify_ratios(
             (&mut output, compressed_output, CheckForCorrectness::No),
             &parameters,

--- a/powersoftau/src/batched_accumulator.rs
+++ b/powersoftau/src/batched_accumulator.rs
@@ -75,7 +75,7 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
 
     /// Verifies a transformation of the `Accumulator` with the `PublicKey`, given a 64-byte transcript `digest`.
     #[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
-    pub fn verify_transformation(
+    pub fn verify_transformation_chunk(
         input: &[u8],
         output: &[u8],
         key: &PublicKey<E>,
@@ -87,6 +87,29 @@ impl<'a, E: Engine + Sync> BatchedAccumulator<'a, E> {
         parameters: &'a CeremonyParams<E>,
     ) -> Result<()> {
         raw_accumulator::verify_chunk(
+            (input, input_is_compressed, check_input_for_correctness),
+            (output, output_is_compressed, check_output_for_correctness),
+            key,
+            digest,
+            parameters,
+        )?;
+        Ok(())
+    }
+
+    /// Verifies a transformation of the `Accumulator` with the `PublicKey`, given a 64-byte transcript `digest`.
+    #[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
+    pub fn verify_transformation_chunk_full(
+        input: &[u8],
+        output: &[u8],
+        key: &PublicKey<E>,
+        digest: &[u8],
+        input_is_compressed: UseCompression,
+        output_is_compressed: UseCompression,
+        check_input_for_correctness: CheckForCorrectness,
+        check_output_for_correctness: CheckForCorrectness,
+        parameters: &'a CeremonyParams<E>,
+    ) -> Result<()> {
+        raw_accumulator::verify_full(
             (input, input_is_compressed, check_input_for_correctness),
             (output, output_is_compressed, check_output_for_correctness),
             key,
@@ -344,7 +367,7 @@ mod tests {
             // ensure that the key is not available to the verifier
             drop(privkey);
 
-            let res = BatchedAccumulator::verify_transformation(
+            let res = BatchedAccumulator::verify_transformation_chunk(
                 &input,
                 &output,
                 &pubkey,
@@ -381,7 +404,7 @@ mod tests {
             // ensure that the key is not available to the verifier
             drop(privkey);
 
-            let res = BatchedAccumulator::verify_transformation(
+            let res = BatchedAccumulator::verify_transformation_chunk(
                 &output,
                 &output_2,
                 &pubkey,
@@ -395,7 +418,7 @@ mod tests {
             assert!(res.is_ok());
 
             // verification will fail if the old hash is used
-            let res = BatchedAccumulator::verify_transformation(
+            let res = BatchedAccumulator::verify_transformation_chunk(
                 &output,
                 &output_2,
                 &pubkey,

--- a/powersoftau/src/bin/powersoftau.rs
+++ b/powersoftau/src/bin/powersoftau.rs
@@ -1,6 +1,7 @@
 use gumdrop::Options;
 use powersoftau::cli_common::{
-    contribute, new_challenge, transform, transform_full, Command, CurveKind, PowersOfTauOpts,
+    combine, contribute, new_challenge, transform, transform_full, Command, CurveKind,
+    PowersOfTauOpts,
 };
 use powersoftau::parameters::CeremonyParams;
 use snark_utils::{beacon_randomness, derive_rng_from_seed};
@@ -33,7 +34,7 @@ fn main() {
 }
 
 fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
-    let parameters = CeremonyParams::<E>::new(opts.power, opts.batch_size, opts.chunk_index);
+    let parameters = CeremonyParams::<E>::new(opts.chunk_index, opts.power, opts.batch_size);
 
     let command = opts.clone().command.unwrap_or_else(|| {
         eprintln!("No command was provided.");
@@ -71,12 +72,10 @@ fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
         }
         Command::VerifyAndTransformFull(opt) => {
             // we receive a previous participation, verify it, and generate a new challenge from it
-            transform_full(
-                &opt.challenge_fname,
-                &opt.response_fname,
-                &opt.new_challenge_fname,
-                &parameters,
-            );
+            transform_full(&opt.response_fname, &parameters);
+        }
+        Command::Combine(opt) => {
+            combine(&opt.response_list_fname, &opt.combined_fname, &parameters);
         }
     };
 

--- a/powersoftau/src/bin/powersoftau.rs
+++ b/powersoftau/src/bin/powersoftau.rs
@@ -1,6 +1,6 @@
 use gumdrop::Options;
 use powersoftau::cli_common::{
-    contribute, new_challenge, transform, Command, CurveKind, PowersOfTauOpts,
+    contribute, new_challenge, transform, transform_full, Command, CurveKind, PowersOfTauOpts,
 };
 use powersoftau::parameters::CeremonyParams;
 use snark_utils::{beacon_randomness, derive_rng_from_seed};
@@ -60,9 +60,18 @@ fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
             let rng = derive_rng_from_seed(&beacon_randomness(beacon_hash));
             contribute(&opt.challenge_fname, &opt.response_fname, &parameters, rng);
         }
-        Command::VerifyAndTransform(opt) => {
+        Command::VerifyAndTransformChunk(opt) => {
             // we receive a previous participation, verify it, and generate a new challenge from it
             transform(
+                &opt.challenge_fname,
+                &opt.response_fname,
+                &opt.new_challenge_fname,
+                &parameters,
+            );
+        }
+        Command::VerifyAndTransformFull(opt) => {
+            // we receive a previous participation, verify it, and generate a new challenge from it
+            transform_full(
                 &opt.challenge_fname,
                 &opt.response_fname,
                 &opt.new_challenge_fname,

--- a/powersoftau/src/bin/powersoftau.rs
+++ b/powersoftau/src/bin/powersoftau.rs
@@ -4,7 +4,7 @@ use powersoftau::cli_common::{
     CurveKind, PowersOfTauOpts,
 };
 use powersoftau::parameters::CeremonyParams;
-use snark_utils::{beacon_randomness, derive_rng_from_seed};
+use snark_utils::{beacon_randomness, derive_rng_from_seed, from_slice};
 
 use std::process;
 use std::time::Instant;
@@ -13,9 +13,6 @@ use tracing_subscriber::{
     fmt::{time::ChronoUtc, Subscriber},
 };
 use zexe_algebra::{Bls12_377, Bls12_381, Bn254, PairingEngine as Engine, BW6_761};
-
-#[macro_use]
-extern crate hex_literal;
 
 fn main() {
     Subscriber::builder()
@@ -63,9 +60,9 @@ fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
         Command::Beacon(opt) => {
             // use the beacon's randomness
             // Place block hash here (block number #564321)
-            let beacon_hash: [u8; 32] =
-                hex!("0000000000000000000a558a61ddc8ee4e488d647a747fe4dcc362fe2026c620");
-            let rng = derive_rng_from_seed(&beacon_randomness(beacon_hash));
+            let beacon_hash =
+                hex::decode(&opt.beacon_hash).expect("could not hex decode beacon hash");
+            let rng = derive_rng_from_seed(&beacon_randomness(from_slice(&beacon_hash)));
             contribute(&opt.challenge_fname, &opt.response_fname, &parameters, rng);
         }
         Command::VerifyAndTransformPokAndCorrectness(opt) => {

--- a/powersoftau/src/bin/powersoftau.rs
+++ b/powersoftau/src/bin/powersoftau.rs
@@ -6,8 +6,7 @@ use powersoftau::cli_common::{
 use powersoftau::parameters::CeremonyParams;
 use snark_utils::{beacon_randomness, derive_rng_from_seed, from_slice};
 
-use std::process;
-use std::time::Instant;
+use std::{fs::read_to_string, process, time::Instant};
 use tracing_subscriber::{
     filter::EnvFilter,
     fmt::{time::ChronoUtc, Subscriber},
@@ -53,7 +52,12 @@ fn execute_cmd<E: Engine>(opts: PowersOfTauOpts) {
         }
         Command::Contribute(opt) => {
             // contribute to the randomness
-            let seed = hex::decode(&opts.seed).expect("seed should be a hex string");
+            let seed = hex::decode(
+                &read_to_string(&opts.seed)
+                    .expect("should have read seed")
+                    .trim(),
+            )
+            .expect("seed should be a hex string");
             let rng = derive_rng_from_seed(&seed);
             contribute(&opt.challenge_fname, &opt.response_fname, &parameters, rng);
         }

--- a/powersoftau/src/bin/prepare_phase2.rs
+++ b/powersoftau/src/bin/prepare_phase2.rs
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
 }
 
 fn prepare_phase2<E: PairingEngine + Sync>(opts: &PreparePhase2Opts) -> Result<()> {
-    let parameters = CeremonyParams::<E>::new(opts.power, opts.batch_size);
+    let parameters = CeremonyParams::<E>::new_for_first_chunk(opts.power, opts.batch_size);
     // Try to load response file from disk.
     let reader = OpenOptions::new()
         .read(true)

--- a/powersoftau/src/bin/prepare_phase2.rs
+++ b/powersoftau/src/bin/prepare_phase2.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
 }
 
 fn prepare_phase2<E: PairingEngine + Sync>(opts: &PreparePhase2Opts) -> Result<()> {
-    let parameters = CeremonyParams::<E>::new_for_first_chunk(opts.power, opts.batch_size);
+    let parameters = CeremonyParams::<E>::new_full(opts.power, opts.batch_size);
     // Try to load response file from disk.
     let reader = OpenOptions::new()
         .read(true)

--- a/powersoftau/src/bin/prepare_phase2.rs
+++ b/powersoftau/src/bin/prepare_phase2.rs
@@ -4,7 +4,7 @@ use powersoftau::{
     parameters::*,
     BatchedAccumulator,
 };
-use snark_utils::{Groth16Params, Result, UseCompression};
+use snark_utils::{CheckForCorrectness, Groth16Params, Result, UseCompression};
 
 use std::time::Instant;
 use zexe_algebra::{Bls12_377, Bls12_381, PairingEngine, BW6_761};
@@ -92,9 +92,13 @@ fn prepare_phase2<E: PairingEngine + Sync>(opts: &PreparePhase2Opts) -> Result<(
         .expect("unable to create parameter file in this directory");
 
     // Deserialize the accumulator
-    let current_accumulator =
-        BatchedAccumulator::deserialize(&response_readable_map, UseCompression::Yes, &parameters)
-            .expect("unable to read uncompressed accumulator");
+    let current_accumulator = BatchedAccumulator::deserialize(
+        &response_readable_map,
+        UseCompression::Yes,
+        CheckForCorrectness::No, // No need to check for correctness since it's been checked by the transcript verifier.
+        &parameters,
+    )
+    .expect("unable to read uncompressed accumulator");
 
     // Load the elements to the Groth16 utility
     let groth16_params = Groth16Params::<E>::new(

--- a/powersoftau/src/bin/prepare_phase2.rs
+++ b/powersoftau/src/bin/prepare_phase2.rs
@@ -7,7 +7,7 @@ use powersoftau::{
 use snark_utils::{CheckForCorrectness, Groth16Params, Result, UseCompression};
 
 use std::time::Instant;
-use zexe_algebra::{Bls12_377, Bls12_381, PairingEngine, BW6_761};
+use zexe_algebra::{Bls12_377, Bls12_381, Bn254, PairingEngine, BW6_761};
 
 use std::fs::OpenOptions;
 
@@ -58,6 +58,7 @@ fn main() -> Result<()> {
         CurveKind::Bls12_381 => prepare_phase2::<Bls12_381>(&opts)?,
         CurveKind::Bls12_377 => prepare_phase2::<Bls12_377>(&opts)?,
         CurveKind::BW6 => prepare_phase2::<BW6_761>(&opts)?,
+        CurveKind::Bn254 => prepare_phase2::<Bn254>(&opts)?,
     }
 
     let new_now = Instant::now();

--- a/powersoftau/src/cli_common/combine.rs
+++ b/powersoftau/src/cli_common/combine.rs
@@ -1,0 +1,100 @@
+use crate::{batched_accumulator::BatchedAccumulator, parameters::CeremonyParams};
+use memmap::*;
+use snark_utils::{blank_hash, UseCompression};
+use std::fs::{File, OpenOptions};
+use zexe_algebra::PairingEngine as Engine;
+
+use std::io::{BufRead, BufReader, Write};
+
+const CONTRIBUTION_IS_COMPRESSED: UseCompression = UseCompression::Yes;
+const COMPRESS_NEW_COMBINED: UseCompression = UseCompression::No;
+
+pub fn combine<T: Engine + Sync>(
+    response_list_filename: &str,
+    combined_filename: &str,
+    parameters: &CeremonyParams<T>,
+) {
+    println!("Will combine contributions",);
+
+    let mut readers = vec![];
+
+    let response_list_reader = BufReader::new(
+        File::open(response_list_filename).expect("should have opened the response list"),
+    );
+    for line in response_list_reader.lines() {
+        let response_reader = OpenOptions::new()
+            .read(true)
+            .open(line.expect("should have read line"))
+            .expect("unable open response file in this directory");
+        {
+            let metadata = response_reader
+                .metadata()
+                .expect("unable to get filesystem metadata for response file");
+            let expected_response_length = match CONTRIBUTION_IS_COMPRESSED {
+                UseCompression::Yes => parameters.contribution_size,
+                UseCompression::No => parameters.accumulator_size + parameters.public_key_size,
+            };
+            if metadata.len() != (expected_response_length as u64) {
+                panic!(
+                    "The size of response file should be {}, but it's {}, so something isn't right.",
+                    expected_response_length,
+                    metadata.len()
+                );
+            }
+        }
+
+        unsafe {
+            readers.push(
+                MmapOptions::new()
+                    .map(&response_reader)
+                    .expect("should have mapped the reader"),
+            );
+        }
+    }
+
+    let writer = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(combined_filename)
+        .expect("unable to create new combined file in this directory");
+
+    writer
+        .set_len(parameters.accumulator_size as u64)
+        .expect("must make output file large enough");
+
+    let mut writable_map = unsafe {
+        MmapOptions::new()
+            .map_mut(&writer)
+            .expect("unable to create a memory map for output")
+    };
+
+    {
+        (&mut writable_map[0..])
+            .write_all(blank_hash().as_slice())
+            .expect("unable to write a default hash to mmap");
+
+        writable_map
+            .flush()
+            .expect("unable to write hash to new challenge file");
+    }
+
+    let res = BatchedAccumulator::combine(
+        readers
+            .iter()
+            .map(|r| r.as_ref())
+            .collect::<Vec<_>>()
+            .as_slice(),
+        CONTRIBUTION_IS_COMPRESSED,
+        &mut writable_map,
+        COMPRESS_NEW_COMBINED,
+        &parameters,
+    );
+
+    if let Err(e) = res {
+        println!("Combining failed: {}", e);
+        panic!("INVALID CONTRIBUTIONS!!!");
+    } else {
+        println!("Combining succeeded!");
+    }
+}

--- a/powersoftau/src/cli_common/combine.rs
+++ b/powersoftau/src/cli_common/combine.rs
@@ -75,9 +75,7 @@ pub fn combine<T: Engine + Sync>(
     println!("parameters for output: {:?}", parameters_for_output);
 
     writer
-        .set_len(
-            parameters_for_output.accumulator_size as u64 - parameters_for_output.hash_size as u64,
-        )
+        .set_len(parameters_for_output.accumulator_size as u64)
         .expect("must make output file large enough");
 
     let mut writable_map = unsafe {

--- a/powersoftau/src/cli_common/contribute.rs
+++ b/powersoftau/src/cli_common/contribute.rs
@@ -1,11 +1,9 @@
 use crate::{
-    batched_accumulator::BatchedAccumulator,
-    keypair::keypair,
-    parameters::CeremonyParams,
+    batched_accumulator::BatchedAccumulator, keypair::keypair, parameters::CeremonyParams,
 };
 use memmap::*;
 use rand::Rng;
-use snark_utils::{calculate_hash, print_hash, UseCompression, CheckForCorrectness};
+use snark_utils::{calculate_hash, print_hash, CheckForCorrectness, UseCompression};
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use zexe_algebra::PairingEngine as Engine;

--- a/powersoftau/src/cli_common/contribute.rs
+++ b/powersoftau/src/cli_common/contribute.rs
@@ -1,11 +1,11 @@
 use crate::{
     batched_accumulator::BatchedAccumulator,
     keypair::keypair,
-    parameters::{CeremonyParams, CheckForCorrectness},
+    parameters::CeremonyParams,
 };
 use memmap::*;
 use rand::Rng;
-use snark_utils::{calculate_hash, print_hash, UseCompression};
+use snark_utils::{calculate_hash, print_hash, UseCompression, CheckForCorrectness};
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use zexe_algebra::PairingEngine as Engine;

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -7,6 +7,9 @@ pub use contribute::contribute;
 mod transform;
 pub use transform::transform;
 
+mod transform_full;
+pub use transform_full::transform_full;
+
 use gumdrop::Options;
 use std::default::Default;
 
@@ -66,9 +69,16 @@ pub enum Command {
         help = "contribute randomness via a random beacon (e.g. a bitcoin block header hash)"
     )]
     Beacon(ContributeOpts),
-    // this receives a challenge + response file, verifies it and generates a new challenge
-    #[options(help = "verify the contributions so far and generate a new challenge")]
-    VerifyAndTransform(VerifyAndTransformOpts),
+    // this receives a challenge + response file, verifies it and generates a new challenge, for a single chunk.
+    #[options(
+        help = "verify the contributions so far and generate a new challenge, for a single chunk"
+    )]
+    VerifyAndTransformChunk(VerifyAndTransformOpts),
+    // this receives a challenge + response file, verifies it and generates a new challenge, for a full contribution.
+    #[options(
+        help = "verify the contributions so far and generate a new challenge, for a full contribution"
+    )]
+    VerifyAndTransformFull(VerifyAndTransformOpts),
 }
 
 // Options for the Contribute command

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -115,6 +115,11 @@ pub struct ContributeOpts {
     pub challenge_fname: String,
     #[options(help = "the response file which will be generated")]
     pub response_fname: String,
+    #[options(
+        help = "the beacon hash to be used if running a beacon contribution",
+        default = "0000000000000000000a558a61ddc8ee4e488d647a747fe4dcc362fe2026c620"
+    )]
+    pub beacon_hash: String,
 }
 
 #[derive(Debug, Options, Clone)]

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -26,6 +26,14 @@ pub enum ProvingSystem {
 pub struct PowersOfTauOpts {
     help: bool,
     #[options(
+        help = "the seed to derive private elements from"
+    )]
+    pub seed: String,
+    #[options(
+    help = "the chunk index to process"
+    )]
+    pub chunk_index: usize,
+    #[options(
         help = "the elliptic curve to use",
         default = "bls12_381",
         parse(try_from_str = "curve_from_str")

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -25,13 +25,9 @@ pub enum ProvingSystem {
 #[derive(Debug, Options, Clone)]
 pub struct PowersOfTauOpts {
     help: bool,
-    #[options(
-        help = "the seed to derive private elements from"
-    )]
+    #[options(help = "the seed to derive private elements from")]
     pub seed: String,
-    #[options(
-    help = "the chunk index to process"
-    )]
+    #[options(help = "the chunk index to process")]
     pub chunk_index: usize,
     #[options(
         help = "the elliptic curve to use",

--- a/powersoftau/src/cli_common/mod.rs
+++ b/powersoftau/src/cli_common/mod.rs
@@ -10,6 +10,9 @@ pub use transform::transform;
 mod transform_full;
 pub use transform_full::transform_full;
 
+mod combine;
+pub use combine::combine;
+
 use gumdrop::Options;
 use std::default::Default;
 
@@ -78,7 +81,12 @@ pub enum Command {
     #[options(
         help = "verify the contributions so far and generate a new challenge, for a full contribution"
     )]
-    VerifyAndTransformFull(VerifyAndTransformOpts),
+    VerifyAndTransformFull(VerifyFullOpts),
+    // this receives a list of chunked reponses and combines them into a single response.
+    #[options(
+        help = "receive a list of chunked reponses and combines them into a single response"
+    )]
+    Combine(CombineOpts),
 }
 
 // Options for the Contribute command
@@ -114,6 +122,28 @@ pub struct VerifyAndTransformOpts {
         default = "new_challenge"
     )]
     pub new_challenge_fname: String,
+}
+
+#[derive(Debug, Options, Clone)]
+pub struct VerifyFullOpts {
+    help: bool,
+    #[options(
+        help = "the provided response file which will be verified",
+        default = "response"
+    )]
+    pub response_fname: String,
+}
+
+#[derive(Debug, Options, Clone)]
+pub struct CombineOpts {
+    help: bool,
+    #[options(
+        help = "the response files which will be combined",
+        default = "response_list"
+    )]
+    pub response_list_fname: String,
+    #[options(help = "the combined response file", default = "combined")]
+    pub combined_fname: String,
 }
 
 pub fn curve_from_str(src: &str) -> Result<CurveKind, String> {

--- a/powersoftau/src/cli_common/transform.rs
+++ b/powersoftau/src/cli_common/transform.rs
@@ -1,10 +1,10 @@
 use crate::{
     batched_accumulator::BatchedAccumulator,
     keypair::PublicKey,
-    parameters::{CeremonyParams, CheckForCorrectness},
+    parameters::{CeremonyParams},
 };
 use memmap::*;
-use snark_utils::{calculate_hash, print_hash, UseCompression};
+use snark_utils::{calculate_hash, print_hash, UseCompression, CheckForCorrectness};
 use std::fs::OpenOptions;
 use zexe_algebra::PairingEngine as Engine;
 

--- a/powersoftau/src/cli_common/transform_full.rs
+++ b/powersoftau/src/cli_common/transform_full.rs
@@ -127,7 +127,7 @@ pub fn transform_full<T: Engine + Sync>(
         "Verifying a contribution to contain proper powers and correspond to the public key..."
     );
 
-    let res = BatchedAccumulator::verify_transformation_chunk_full(
+    let res = BatchedAccumulator::verify_transformation_full(
         &challenge_readable_map,
         &response_readable_map,
         &public_key,

--- a/powersoftau/src/cli_common/transform_full.rs
+++ b/powersoftau/src/cli_common/transform_full.rs
@@ -12,7 +12,7 @@ const PREVIOUS_CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
 const CONTRIBUTION_IS_COMPRESSED: UseCompression = UseCompression::Yes;
 const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
 
-pub fn transform<T: Engine + Sync>(
+pub fn transform_full<T: Engine + Sync>(
     challenge_filename: &str,
     response_filename: &str,
     new_challenge_filename: &str,
@@ -127,7 +127,7 @@ pub fn transform<T: Engine + Sync>(
         "Verifying a contribution to contain proper powers and correspond to the public key..."
     );
 
-    let res = BatchedAccumulator::verify_transformation_chunk(
+    let res = BatchedAccumulator::verify_transformation_chunk_full(
         &challenge_readable_map,
         &response_readable_map,
         &public_key,

--- a/powersoftau/src/cli_common/transform_full.rs
+++ b/powersoftau/src/cli_common/transform_full.rs
@@ -1,56 +1,16 @@
-use crate::{
-    batched_accumulator::BatchedAccumulator, keypair::PublicKey, parameters::CeremonyParams,
-};
+use crate::{batched_accumulator::BatchedAccumulator, parameters::CeremonyParams};
 use memmap::*;
 use snark_utils::{calculate_hash, print_hash, CheckForCorrectness, UseCompression};
 use std::fs::OpenOptions;
 use zexe_algebra::PairingEngine as Engine;
 
-use std::io::{Read, Write};
-
-const PREVIOUS_CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
 const CONTRIBUTION_IS_COMPRESSED: UseCompression = UseCompression::Yes;
-const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
 
-pub fn transform_full<T: Engine + Sync>(
-    challenge_filename: &str,
-    response_filename: &str,
-    new_challenge_filename: &str,
-    parameters: &CeremonyParams<T>,
-) {
+pub fn transform_full<T: Engine + Sync>(response_filename: &str, parameters: &CeremonyParams<T>) {
     println!(
         "Will verify and decompress a contribution to accumulator for 2^{} powers of tau",
         parameters.size
     );
-
-    // Try to load challenge file from disk.
-    let challenge_reader = OpenOptions::new()
-        .read(true)
-        .open(challenge_filename)
-        .expect("unable open challenge file in this directory");
-
-    {
-        let metadata = challenge_reader
-            .metadata()
-            .expect("unable to get filesystem metadata for challenge file");
-        let expected_challenge_length = match PREVIOUS_CHALLENGE_IS_COMPRESSED {
-            UseCompression::Yes => parameters.contribution_size - parameters.public_key_size,
-            UseCompression::No => parameters.accumulator_size,
-        };
-        if metadata.len() != (expected_challenge_length as u64) {
-            panic!(
-                "The size of challenge file should be {}, but it's {}, so something isn't right.",
-                expected_challenge_length,
-                metadata.len()
-            );
-        }
-    }
-
-    let challenge_readable_map = unsafe {
-        MmapOptions::new()
-            .map(&challenge_reader)
-            .expect("unable to create a memory map for input")
-    };
 
     // Try to load response file from disk.
     let response_reader = OpenOptions::new()
@@ -81,61 +41,20 @@ pub fn transform_full<T: Engine + Sync>(
             .expect("unable to create a memory map for input")
     };
 
-    println!("Calculating previous challenge hash...");
-
-    // Check that contribution is correct
-
-    let current_accumulator_hash = calculate_hash(&challenge_readable_map);
-
-    println!("Hash of the `challenge` file for verification:");
-    print_hash(&current_accumulator_hash);
-
-    // Check the hash chain - a new response must be based on the previous challenge!
-    {
-        let mut response_challenge_hash = [0; 64];
-        let mut memory_slice = response_readable_map
-            .get(0..64)
-            .expect("must read point data from file");
-        memory_slice
-            .read_exact(&mut response_challenge_hash)
-            .expect("couldn't read hash of challenge file from response file");
-
-        println!("`response` was based on the hash:");
-        print_hash(&response_challenge_hash);
-
-        if &response_challenge_hash[..] != current_accumulator_hash.as_slice() {
-            panic!("Hash chain failure. This is not the right response.");
-        }
-    }
-
     let response_hash = calculate_hash(&response_readable_map);
 
     println!("Hash of the response file for verification:");
     print_hash(&response_hash);
 
-    // get the contributor's public key
-    let public_key = PublicKey::read(
-        &response_readable_map,
-        CONTRIBUTION_IS_COMPRESSED,
-        &parameters,
-    )
-    .expect("wasn't able to deserialize the response file's public key");
-
     // check that it follows the protocol
-
     println!(
         "Verifying a contribution to contain proper powers and correspond to the public key..."
     );
 
     let res = BatchedAccumulator::verify_transformation_full(
-        &challenge_readable_map,
         &response_readable_map,
-        &public_key,
-        current_accumulator_hash.as_slice(),
-        PREVIOUS_CHALLENGE_IS_COMPRESSED,
         CONTRIBUTION_IS_COMPRESSED,
         CheckForCorrectness::No,
-        CheckForCorrectness::Yes,
         &parameters,
     );
 
@@ -144,63 +63,5 @@ pub fn transform_full<T: Engine + Sync>(
         panic!("INVALID CONTRIBUTION!!!");
     } else {
         println!("Verification succeeded!");
-    }
-
-    if COMPRESS_NEW_CHALLENGE == UseCompression::Yes {
-        println!(
-            "Don't need to recompress the contribution, please copy response file as new challenge"
-        );
-    } else {
-        println!("Verification succeeded! Writing to new challenge file...");
-
-        // Create new challenge file in this directory
-        let writer = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create_new(true)
-            .open(new_challenge_filename)
-            .expect("unable to create new challenge file in this directory");
-
-        // Recomputation strips the public key and uses hashing to link with the previous contribution after decompression
-        writer
-            .set_len(parameters.accumulator_size as u64)
-            .expect("must make output file large enough");
-
-        let mut writable_map = unsafe {
-            MmapOptions::new()
-                .map_mut(&writer)
-                .expect("unable to create a memory map for output")
-        };
-
-        {
-            (&mut writable_map[0..])
-                .write_all(response_hash.as_slice())
-                .expect("unable to write a default hash to mmap");
-
-            writable_map
-                .flush()
-                .expect("unable to write hash to new challenge file");
-        }
-
-        BatchedAccumulator::decompress(
-            &response_readable_map,
-            &mut writable_map,
-            CheckForCorrectness::No,
-            &parameters,
-        )
-        .expect("must decompress a response for a new challenge");
-
-        writable_map.flush().expect("must flush the memory map");
-
-        let new_challenge_readable_map = writable_map
-            .make_read_only()
-            .expect("must make a map readonly");
-
-        let recompressed_hash = calculate_hash(&new_challenge_readable_map);
-
-        println!("Here's the BLAKE2b hash of the decompressed participant's response as new_challenge file:");
-        print_hash(&recompressed_hash);
-        println!("Done! new challenge file contains the new challenge file. The other files");
-        println!("were left alone.");
     }
 }

--- a/powersoftau/src/cli_common/transform_pok_and_correctness.rs
+++ b/powersoftau/src/cli_common/transform_pok_and_correctness.rs
@@ -12,7 +12,7 @@ const PREVIOUS_CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
 const CONTRIBUTION_IS_COMPRESSED: UseCompression = UseCompression::Yes;
 const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
 
-pub fn transform<T: Engine + Sync>(
+pub fn transform_pok_and_correctness<T: Engine + Sync>(
     challenge_filename: &str,
     response_filename: &str,
     new_challenge_filename: &str,
@@ -127,7 +127,7 @@ pub fn transform<T: Engine + Sync>(
         "Verifying a contribution to contain proper powers and correspond to the public key..."
     );
 
-    let res = BatchedAccumulator::verify_transformation_chunk(
+    let res = BatchedAccumulator::verify_transformation_pok_and_correctness(
         &challenge_readable_map,
         &response_readable_map,
         &public_key,
@@ -135,7 +135,7 @@ pub fn transform<T: Engine + Sync>(
         PREVIOUS_CHALLENGE_IS_COMPRESSED,
         CONTRIBUTION_IS_COMPRESSED,
         CheckForCorrectness::No,
-        CheckForCorrectness::Yes,
+        CheckForCorrectness::Both,
         &parameters,
     );
 

--- a/powersoftau/src/cli_common/transform_ratios.rs
+++ b/powersoftau/src/cli_common/transform_ratios.rs
@@ -1,4 +1,3 @@
-use crate::parameters::ContributionMode;
 use crate::{batched_accumulator::BatchedAccumulator, parameters::CeremonyParams};
 use memmap::*;
 use snark_utils::{calculate_hash, print_hash, CheckForCorrectness, UseCompression};
@@ -28,10 +27,7 @@ pub fn transform_ratios<T: Engine + Sync>(response_filename: &str, parameters: &
         let metadata = response_reader
             .metadata()
             .expect("unable to get filesystem metadata for response file");
-        let expected_response_length = match parameters.contribution_mode {
-            ContributionMode::Chunked => parameters.accumulator_size - parameters.hash_size,
-            ContributionMode::Full => parameters.accumulator_size,
-        };
+        let expected_response_length = parameters.accumulator_size;
         if metadata.len() != (expected_response_length as u64) {
             panic!(
                 "The size of response file should be {}, but it's {}, so something isn't right.",

--- a/powersoftau/src/cli_common/transform_ratios.rs
+++ b/powersoftau/src/cli_common/transform_ratios.rs
@@ -1,4 +1,3 @@
-use crate::keypair::PublicKey;
 use crate::parameters::ContributionMode;
 use crate::{batched_accumulator::BatchedAccumulator, parameters::CeremonyParams};
 use memmap::*;

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -97,18 +97,10 @@ pub struct CeremonyParams<E> {
 impl<E: PairingEngine> CeremonyParams<E> {
     /// Constructs a new ceremony parameters object from the type of provided curve
     /// Panics if given batch_size = 0
-    pub fn new_for_first_chunk(size: usize, batch_size: usize) -> Self {
+    pub fn new_full(size: usize, batch_size: usize) -> Self {
         // create the curve
         let curve = CurveParams::<E>::new();
-        //TODO(kobi): meh
-        Self::new_with_curve(
-            ContributionMode::Full,
-            0,
-            batch_size,
-            curve,
-            size,
-            batch_size,
-        )
+        Self::new_with_curve(ContributionMode::Full, 0, 0, curve, size, batch_size)
     }
 
     pub fn new(

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -186,9 +186,7 @@ impl<E: PairingEngine> CeremonyParams<E> {
     }
 
     pub fn specialize_to_chunk(&self, chunk_index: usize) -> Self {
-        let mut params = self.clone();
-        params.chunk_index = chunk_index;
-        params
+        Self::new_with_curve(chunk_index, self.curve.clone(), self.size, self.batch_size)
     }
 }
 

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -186,15 +186,6 @@ impl<E: PairingEngine> CeremonyParams<E> {
     }
 }
 
-/// Determines if points should be checked for correctness during deserialization.
-/// This is not necessary for participants, because a transcript verifier can
-/// check this theirself.
-#[derive(Copy, Clone, PartialEq)]
-pub enum CheckForCorrectness {
-    Yes,
-    No,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -62,6 +62,8 @@ impl<E> CurveParams<E> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// The parameters used for the trusted setup ceremony
 pub struct CeremonyParams<E> {
+    /// The chunk index
+    pub chunk_index: usize,
     /// The type of the curve being used
     pub curve: CurveParams<E>,
     /// The number of Powers of Tau G1 elements which will be accumulated
@@ -70,8 +72,6 @@ pub struct CeremonyParams<E> {
     pub powers_length: usize,
     /// The circuit size exponent (ie length will be 2^size), depends on the computation you want to support
     pub size: usize,
-    // The index of the chunk to process.
-    pub chunk_index: usize,
     /// The size of each chunk.
     pub batch_size: usize,
     // Size of the used public key
@@ -90,22 +90,22 @@ impl<E: PairingEngine> CeremonyParams<E> {
     pub fn new_for_first_chunk(size: usize, batch_size: usize) -> Self {
         // create the curve
         let curve = CurveParams::<E>::new();
-        Self::new_with_curve(curve, size, batch_size, 0)
+        Self::new_with_curve(0, curve, size, batch_size)
     }
 
-    pub fn new(size: usize, batch_size: usize, chunk_index: usize) -> Self {
+    pub fn new(chunk_index: usize, size: usize, batch_size: usize) -> Self {
         // create the curve
         let curve = CurveParams::<E>::new();
-        Self::new_with_curve(curve, size, batch_size, chunk_index)
+        Self::new_with_curve(chunk_index, curve, size, batch_size)
     }
 
     /// Constructs a new ceremony parameters object from the directly provided curve with parameters
     /// Consider using the `new` method if you want to use one of the pre-implemented curves
     pub fn new_with_curve(
+        chunk_index: usize,
         curve: CurveParams<E>,
         size: usize,
         batch_size: usize,
-        chunk_index: usize,
     ) -> Self {
         // assume we're using a 64 byte long hash function such as Blake
         let hash_size = 64;
@@ -155,9 +155,9 @@ impl<E: PairingEngine> CeremonyParams<E> {
             public_key_size;
 
         Self {
+            chunk_index,
             curve,
             size,
-            chunk_index,
             batch_size,
             accumulator_size,
             public_key_size,
@@ -183,6 +183,12 @@ impl<E: PairingEngine> CeremonyParams<E> {
             self.powers_g1_length,
             self.powers_length,
         )
+    }
+
+    pub fn specialize_to_chunk(&self, chunk_index: usize) -> Self {
+        let mut params = self.clone();
+        params.chunk_index = chunk_index;
+        params
     }
 }
 

--- a/powersoftau/src/parameters.rs
+++ b/powersoftau/src/parameters.rs
@@ -101,7 +101,12 @@ impl<E: PairingEngine> CeremonyParams<E> {
 
     /// Constructs a new ceremony parameters object from the directly provided curve with parameters
     /// Consider using the `new` method if you want to use one of the pre-implemented curves
-    pub fn new_with_curve(curve: CurveParams<E>, size: usize, batch_size: usize, chunk_index: usize) -> Self {
+    pub fn new_with_curve(
+        curve: CurveParams<E>,
+        size: usize,
+        batch_size: usize,
+        chunk_index: usize,
+    ) -> Self {
         // assume we're using a 64 byte long hash function such as Blake
         let hash_size = 64;
 
@@ -110,7 +115,8 @@ impl<E: PairingEngine> CeremonyParams<E> {
         // 2^{size+1} - 1
         let powers_g1_length = (powers_length << 1) - 1;
 
-        let (g1_els_size, other_els_size) = chunk_element_sizes(batch_size, chunk_index, powers_g1_length, powers_length);
+        let (g1_els_size, other_els_size) =
+            chunk_element_sizes(batch_size, chunk_index, powers_g1_length, powers_length);
 
         let accumulator_size =
             // G1 Tau powers
@@ -171,7 +177,12 @@ impl<E: PairingEngine> CeremonyParams<E> {
     }
 
     pub fn chunk_element_sizes(&self) -> (usize, usize) {
-        chunk_element_sizes(self.batch_size, self.chunk_index, self.powers_g1_length, self.powers_length)
+        chunk_element_sizes(
+            self.batch_size,
+            self.chunk_index,
+            self.powers_g1_length,
+            self.powers_length,
+        )
     }
 }
 
@@ -216,10 +227,7 @@ pub fn chunk_element_sizes(
     powers_g1_length: usize,
     powers_length: usize,
 ) -> (usize, usize) {
-    let (start, end) = (
-        chunk_index*batch_size,
-        (chunk_index + 1)*batch_size,
-    );
+    let (start, end) = (chunk_index * batch_size, (chunk_index + 1) * batch_size);
     let g1_els_in_chunk = if end > powers_g1_length {
         powers_g1_length - start
     } else {

--- a/powersoftau/src/raw/raw_accumulator.rs
+++ b/powersoftau/src/raw/raw_accumulator.rs
@@ -75,7 +75,7 @@ fn iter_chunk(
                 } // ensure there's overlap between chunks
                 MinMaxResult::OneElement(start) => (
                     start,
-                    if start >= min - 1 {
+                    if start >= max - 1 {
                         start + 1
                     } else {
                         start + 2

--- a/powersoftau/src/raw/raw_accumulator.rs
+++ b/powersoftau/src/raw/raw_accumulator.rs
@@ -450,11 +450,11 @@ pub fn decompress<E: PairingEngine>(
     }
 
     // decompress tau_single_g1
-    decompress_buffer::<E::G1Affine>(tau_single_g1, in_tau_single_g1, (0, 3))
+    decompress_buffer::<E::G1Affine>(tau_single_g1, in_tau_single_g1, (0, 2))
         .expect("could not decompress the TauSingleG1 elements");
 
     // decompress tau_single_g2
-    decompress_buffer::<E::G2Affine>(tau_single_g2, in_tau_single_g2, (0, 3))
+    decompress_buffer::<E::G2Affine>(tau_single_g2, in_tau_single_g2, (0, 2))
         .expect("could not decompress the TauSingleG2 elements");
 
 

--- a/powersoftau/src/raw/raw_accumulator.rs
+++ b/powersoftau/src/raw/raw_accumulator.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use snark_utils::*;
 use snark_utils::{BatchDeserializer, BatchSerializer, Deserializer};
-use zexe_algebra::{AffineCurve, PairingEngine, ProjectiveCurve, Zero};
+use zexe_algebra::{AffineCurve, FpParameters, PairingEngine, PrimeField, ProjectiveCurve, Zero};
 
 use tracing::{debug, info, info_span, trace};
 
@@ -146,6 +146,31 @@ fn check_power_ratios<E: PairingEngine>(
     Ok(())
 }
 
+/// Reads a list of G1 elements from the buffer to the provided `elements` slice
+/// and then checks that their powers pairs ratio matches the one from the
+/// provided `check` pair
+fn check_elements_are_non_zero_and_in_prime_order_subgroup<C: AffineCurve>(
+    (buffer, compression): (&[u8], UseCompression),
+    (start, end): (usize, usize),
+    elements: &mut [C],
+) -> Result<()> {
+    let size = buffer_size::<C>(compression);
+    buffer[start * size..end * size].read_batch_preallocated(
+        &mut elements[0..end - start],
+        compression,
+        CheckForCorrectness::Yes,
+    )?;
+    // TODO(kobi): replace with batch subgroup check
+    let all_in_prime_order_subgroup = elements.iter().all(|p| {
+        p.mul(<<C::ScalarField as PrimeField>::Params as FpParameters>::MODULUS)
+            .is_zero()
+    });
+    if !all_in_prime_order_subgroup {
+        return Err(Error::IncorrectSubgroup);
+    }
+    Ok(())
+}
+
 /// Reads a list of G2 elements from the buffer to the provided `elements` slice
 /// and then checks that their powers pairs ratio matches the one from the
 /// provided `check` pair
@@ -198,8 +223,218 @@ fn read_initial_elements_with_amount<C: AffineCurve>(
 }
 
 /// Verifies that the accumulator was transformed correctly
-/// given the `PublicKey` and the so-far hash of the accumulator
-pub fn verify<E: PairingEngine>(
+/// given the `PublicKey` and the so-far hash of the accumulator.
+/// This verifies a single chunk and checks only that the points
+/// are not zero, that they're in the prime order subgroup.
+/// In the first chunk, it also checks the proofs of knowledge
+/// and that the elements were correctly multiplied.
+pub fn verify_chunk<E: PairingEngine>(
+    (input, compressed_input, check_input_for_correctness): (
+        &[u8],
+        UseCompression,
+        CheckForCorrectness,
+    ),
+    (output, compressed_output, check_output_for_correctness): (
+        &[u8],
+        UseCompression,
+        CheckForCorrectness,
+    ),
+    key: &PublicKey<E>,
+    digest: &[u8],
+    parameters: &CeremonyParams<E>,
+) -> Result<()> {
+    let span = info_span!("phase1-verify");
+    let _enter = span.enter();
+
+    info!("starting...");
+    // Split the buffers
+    // todo: check that in_tau_g2 is actually not required
+    let (in_tau_g1, _, in_alpha_g1, in_beta_g1, in_beta_g2) =
+        split(input, parameters, compressed_input);
+    let (tau_g1, tau_g2, alpha_g1, beta_g1, beta_g2) = split(output, parameters, compressed_output);
+
+    if parameters.chunk_index == 0 {
+        // Ensure the key ratios are correctly produced
+        let [tau_g2_s, alpha_g2_s, beta_g2_s] = compute_g2_s_key(&key, &digest)?;
+        // put in tuple form for convenience
+        // Check the proofs-of-knowledge for tau/alpha/beta
+        let tau_single_g1_check = &(key.tau_g1.0, key.tau_g1.1);
+        let tau_single_g2_check = &(tau_g2_s, key.tau_g2);
+        //let alpha_single_g1_check = &(key.alpha_g1.0, key.alpha_g1.1);
+        let alpha_single_g2_check = &(alpha_g2_s, key.alpha_g2);
+        let beta_single_g1_check = &(key.beta_g1.0, key.beta_g1.1);
+        let beta_single_g2_check = &(beta_g2_s, key.beta_g2);
+
+        let check_ratios = &[
+            (
+                &(key.tau_g1.0, key.tau_g1.1),
+                &(tau_g2_s, key.tau_g2),
+                "Tau G1<>G2",
+            ),
+            (
+                &(key.alpha_g1.0, key.alpha_g1.1),
+                &(alpha_g2_s, key.alpha_g2),
+                "Alpha G1<>G2",
+            ),
+            (
+                &(key.beta_g1.0, key.beta_g1.1),
+                &(beta_g2_s, key.beta_g2),
+                "Beta G1<>G2",
+            ),
+        ];
+
+        for (a, b, err) in check_ratios {
+            check_same_ratio::<E>(a, b, err)?;
+        }
+        debug!("key ratios were correctly produced");
+
+        // Ensure that the initial conditions are correctly formed (first 2 elements)
+        // We allocate a G1 vector of length 2 and re-use it for our G1 elements.
+        // We keep the values of the Tau G1/G2 telements for later use.
+
+        let mut before_g1 = read_initial_elements::<E::G1Affine>(
+            in_tau_g1,
+            compressed_input,
+            check_input_for_correctness,
+        )?;
+        let mut after_g1 = read_initial_elements::<E::G1Affine>(
+            tau_g1,
+            compressed_output,
+            check_output_for_correctness,
+        )?;
+        if after_g1[0] != E::G1Affine::prime_subgroup_generator() {
+            return Err(VerificationError::InvalidGenerator(ElementType::TauG1).into());
+        }
+        let after_g2 = read_initial_elements::<E::G2Affine>(
+            tau_g2,
+            compressed_output,
+            check_output_for_correctness,
+        )?;
+        if after_g2[0] != E::G2Affine::prime_subgroup_generator() {
+            return Err(VerificationError::InvalidGenerator(ElementType::TauG2).into());
+        }
+        // Check Tau was multiplied correctly in G1
+        check_same_ratio::<E>(
+            &(before_g1[1], after_g1[1]),
+            tau_single_g2_check,
+            "Before-After: Tau G1",
+        )?;
+
+        // Check Alpha and Beta were multiplied correctly in G1.
+        for (before, after, check) in &[
+            (in_alpha_g1, alpha_g1, alpha_single_g2_check),
+            (in_beta_g1, beta_g1, beta_single_g2_check),
+        ] {
+            before.read_batch_preallocated(
+                &mut before_g1,
+                compressed_input,
+                check_input_for_correctness,
+            )?;
+            after.read_batch_preallocated(
+                &mut after_g1,
+                compressed_output,
+                check_output_for_correctness,
+            )?;
+            check_same_ratio::<E>(
+                &(before_g1[0], after_g1[0]),
+                check,
+                "Before-After: Alpha/Beta[0]",
+            )?;
+        }
+
+        // Check Beta was multiplied correctly in G1.
+        let before_beta_g2 = (&*in_beta_g2)
+            .read_element::<E::G2Affine>(compressed_input, check_input_for_correctness)?;
+        let after_beta_g2 = (&*beta_g2)
+            .read_element::<E::G2Affine>(compressed_output, check_output_for_correctness)?;
+        check_same_ratio::<E>(
+            beta_single_g1_check,
+            &(before_beta_g2, after_beta_g2),
+            "Before-After: Beta Single G2[0] G1<>G2",
+        )?;
+    }
+
+    debug!("initial elements were computed correctly");
+
+    let start = parameters.chunk_index * parameters.batch_size;
+    let end = (parameters.chunk_index + 1) * parameters.batch_size;
+    let (g1_els_in_chunk, other_els_in_chunk) = parameters.chunk_element_sizes();
+
+    // preallocate 2 vectors per batch
+    // Ensure that the pairs are created correctly (we do this in chunks!)
+    // load `batch_size` chunks on each iteration and perform the transformation
+    debug!("verifying chunk from {} to {}", start, end);
+    let span = info_span!("batch", start, end);
+    let _enter = span.enter();
+    rayon::scope(|t| {
+        let _enter = span.enter();
+        t.spawn(|_| {
+            let _enter = span.enter();
+            let mut g1 = vec![E::G1Affine::zero(); g1_els_in_chunk];
+            check_elements_are_non_zero_and_in_prime_order_subgroup::<E::G1Affine>(
+                (tau_g1, compressed_output),
+                (0, g1_els_in_chunk),
+                &mut g1,
+            )
+            .expect("could not check ratios for Tau G1");
+
+            trace!("tau g1 verification successful");
+        });
+
+        if other_els_in_chunk > 0 {
+            rayon::scope(|t| {
+                let _enter = span.enter();
+                t.spawn(|_| {
+                    let _enter = span.enter();
+                    let mut g2 = vec![E::G2Affine::zero(); other_els_in_chunk];
+                    check_elements_are_non_zero_and_in_prime_order_subgroup::<E::G2Affine>(
+                        (tau_g2, compressed_output),
+                        (0, other_els_in_chunk),
+                        &mut g2,
+                    )
+                    .expect("could not check ratios for Tau G2");
+                    trace!("tau g2 verification successful");
+                });
+
+                t.spawn(|_| {
+                    let _enter = span.enter();
+                    let mut g1 = vec![E::G1Affine::zero(); other_els_in_chunk];
+                    check_elements_are_non_zero_and_in_prime_order_subgroup::<E::G1Affine>(
+                        (alpha_g1, compressed_output),
+                        (0, other_els_in_chunk),
+                        &mut g1,
+                    )
+                    .expect("could not check ratios for Alpha G1");
+
+                    trace!("alpha g1 verification successful");
+                });
+
+                t.spawn(|_| {
+                    let _enter = span.enter();
+                    let mut g1 = vec![E::G1Affine::zero(); other_els_in_chunk];
+                    check_elements_are_non_zero_and_in_prime_order_subgroup::<E::G1Affine>(
+                        (beta_g1, compressed_output),
+                        (0, other_els_in_chunk),
+                        &mut g1,
+                    )
+                    .expect("could not check ratios for Beta G1");
+
+                    trace!("beta g1 verification successful");
+                });
+            });
+        }
+    });
+    debug!("chunk verification successful");
+
+    info!("verification complete");
+    Ok(())
+}
+
+/// Verifies that the accumulator was transformed correctly
+/// given the `PublicKey` and the so-far hash of the accumulator.
+/// This verifies a single chunk and checks only that the points
+/// are not zero and that they're in the prime order subgroup.
+pub fn verify_combined<E: PairingEngine>(
     (input, compressed_input, check_input_for_correctness): (
         &[u8],
         UseCompression,
@@ -683,8 +918,10 @@ mod tests {
         let len = num_els * buffer_size::<C>(UseCompression::No);
         let mut out = vec![0; len];
         // perform the decompression
-        decompress_buffer::<C>(&mut out, &input, (0, num_els)).unwrap();
-        let deserialized = out.read_batch::<C>(UseCompression::No).unwrap();
+        decompress_buffer::<C>(&mut out, &input, (0, num_els), CheckForCorrectness::No).unwrap();
+        let deserialized = out
+            .read_batch::<C>(UseCompression::No, CheckForCorrectness::No)
+            .unwrap();
         // ensure they match
         assert_eq!(deserialized, elements);
     }

--- a/snark-utils/Cargo.toml
+++ b/snark-utils/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0.11"
-zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", version = "0.1.0", features = ["parallel"] }
-zexe_fft = { package = "ff-fft", git = "https://github.com/scipr-lab/zexe", version = "0.1.0", features = ["parallel"] }
+zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel"] }
+zexe_fft = { package = "ff-fft", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel"] }
 rayon = { version = "1.3.0", optional = true }
 
 # crypto lower-level crates
@@ -21,13 +21,13 @@ crossbeam = "0.7.3"
 num_cpus = "1.12.0"
 blake2 = "0.8.1"
 blake2s_simd = "0.5.10"
-zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", version = "0.1.0" }
+zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1" }
 tracing = "0.1.13"
 
 [dev-dependencies]
 criterion = "0.3.1"
 test-helpers = { path = "../test-helpers" }
-zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", version = "0.1.0", features = ["parallel", "full"] }
+zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel", "full"] }
 powersoftau = { path = "../powersoftau" }
 
 [[bench]]

--- a/snark-utils/Cargo.toml
+++ b/snark-utils/Cargo.toml
@@ -20,6 +20,7 @@ rust-crypto = "0.2"
 crossbeam = "0.7.3"
 num_cpus = "1.12.0"
 blake2 = "0.8.1"
+blake2s_simd = "0.5.10"
 zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", version = "0.1.0" }
 tracing = "0.1.13"
 

--- a/snark-utils/benches/io.rs
+++ b/snark-utils/benches/io.rs
@@ -44,7 +44,7 @@ fn read<C: AffineCurve>(c: &mut Criterion, el_type: &str) {
                 &num_els,
                 |b, _num_els| {
                     b.iter(|| {
-                        buf.read_batch::<C>(*compression, CheckForCorrectness::Yes)
+                        buf.read_batch::<C>(*compression, CheckForCorrectness::Both)
                             .unwrap()
                     });
                 },

--- a/snark-utils/src/elements.rs
+++ b/snark-utils/src/elements.rs
@@ -21,14 +21,18 @@ impl fmt::Display for UseCompression {
 /// check this theirself.
 #[derive(Copy, Clone, PartialEq)]
 pub enum CheckForCorrectness {
-    Yes,
+    Both,
+    OnlyNonZero,
+    OnlyInGroup,
     No,
 }
 
 impl fmt::Display for CheckForCorrectness {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            CheckForCorrectness::Yes => write!(f, "Yes"),
+            CheckForCorrectness::Both => write!(f, "Both"),
+            CheckForCorrectness::OnlyNonZero => write!(f, "OnlyNonZero"),
+            CheckForCorrectness::OnlyInGroup => write!(f, "OnlyInGroup"),
             CheckForCorrectness::No => write!(f, "No"),
         }
     }

--- a/snark-utils/src/elements.rs
+++ b/snark-utils/src/elements.rs
@@ -16,6 +16,24 @@ impl fmt::Display for UseCompression {
     }
 }
 
+/// Determines if points should be checked for correctness during deserialization.
+/// This is not necessary for participants, because a transcript verifier can
+/// check this theirself.
+#[derive(Copy, Clone, PartialEq)]
+pub enum CheckForCorrectness {
+    Yes,
+    No,
+}
+
+impl fmt::Display for CheckForCorrectness {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CheckForCorrectness::Yes => write!(f, "Yes"),
+            CheckForCorrectness::No => write!(f, "No"),
+        }
+    }
+}
+
 // todo: remove this, we can always get the size of the element
 // from the `buffer_size` method
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/snark-utils/src/errors.rs
+++ b/snark-utils/src/errors.rs
@@ -30,6 +30,8 @@ pub enum Error {
     CrossBeamError,
     #[error("Got point not in the prime order subgroup")]
     IncorrectSubgroup,
+    #[error("Got invalid decompression parameters")]
+    InvalidDecompressionParametersError,
 }
 
 impl From<Box<dyn std::any::Any + Send>> for Error {

--- a/snark-utils/src/errors.rs
+++ b/snark-utils/src/errors.rs
@@ -28,6 +28,8 @@ pub enum Error {
     Phase2Error(#[from] Phase2Error),
     #[error("Crossbeam error during while joining the thread")]
     CrossBeamError,
+    #[error("Got point not in the prime order subgroup")]
+    IncorrectSubgroup,
 }
 
 impl From<Box<dyn std::any::Any + Send>> for Error {

--- a/snark-utils/src/groth16_utils.rs
+++ b/snark-utils/src/groth16_utils.rs
@@ -310,7 +310,7 @@ mod tests {
         compressed: UseCompression,
     ) {
         let batch = 2;
-        let params = CeremonyParams::<E>::new(powers, batch);
+        let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
         let (_, output, _, _) = setup_verify(compressed, compressed, &params);
         let accumulator = BatchedAccumulator::deserialize(&output, compressed, &params).unwrap();
 

--- a/snark-utils/src/groth16_utils.rs
+++ b/snark-utils/src/groth16_utils.rs
@@ -320,7 +320,7 @@ mod tests {
         compressed: UseCompression,
     ) {
         let batch = ((1 << powers) << 1) - 1;
-        let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
+        let params = CeremonyParams::<E>::new_full(powers, batch);
         let (_, output, _, _) = setup_verify(compressed, compressed, &params);
         let accumulator =
             BatchedAccumulator::deserialize(&output, compressed, CheckForCorrectness::No, &params)
@@ -392,6 +392,8 @@ mod tests {
     fn compat_correctness(check_for_correctness: CheckForCorrectness) -> CheckForCorrectnessV1 {
         match check_for_correctness {
             CheckForCorrectness::Both => CheckForCorrectnessV1::Both,
+            CheckForCorrectness::OnlyNonZero => CheckForCorrectnessV1::OnlyNonZero,
+            CheckForCorrectness::OnlyInGroup => CheckForCorrectnessV1::OnlyInGroup,
             CheckForCorrectness::No => CheckForCorrectnessV1::No,
         }
     }

--- a/snark-utils/src/groth16_utils.rs
+++ b/snark-utils/src/groth16_utils.rs
@@ -391,7 +391,7 @@ mod tests {
 
     fn compat_correctness(check_for_correctness: CheckForCorrectness) -> CheckForCorrectnessV1 {
         match check_for_correctness {
-            CheckForCorrectness::Yes => CheckForCorrectnessV1::Yes,
+            CheckForCorrectness::Both => CheckForCorrectnessV1::Both,
             CheckForCorrectness::No => CheckForCorrectnessV1::No,
         }
     }

--- a/snark-utils/src/groth16_utils.rs
+++ b/snark-utils/src/groth16_utils.rs
@@ -309,7 +309,7 @@ mod tests {
         prepared_phase1_size: usize,
         compressed: UseCompression,
     ) {
-        let batch = 2;
+        let batch = ((1 << powers) << 1) - 1;
         let params = CeremonyParams::<E>::new_for_first_chunk(powers, batch);
         let (_, output, _, _) = setup_verify(compressed, compressed, &params);
         let accumulator = BatchedAccumulator::deserialize(&output, compressed, &params).unwrap();

--- a/snark-utils/src/helpers.rs
+++ b/snark-utils/src/helpers.rs
@@ -504,4 +504,3 @@ fn dense_multiexp_inner<G: AffineCurve>(
         next_region
     }
 }
-

--- a/snark-utils/src/helpers.rs
+++ b/snark-utils/src/helpers.rs
@@ -504,3 +504,4 @@ fn dense_multiexp_inner<G: AffineCurve>(
         next_region
     }
 }
+

--- a/snark-utils/src/io/mod.rs
+++ b/snark-utils/src/io/mod.rs
@@ -19,6 +19,7 @@ pub fn buffer_size<C: AffineCurve>(compression: UseCompression) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CheckForCorrectness;
     use rand::thread_rng;
     use test_helpers::random_point_vec;
     use zexe_algebra::bls12_377::{G1Affine, G2Affine};
@@ -61,7 +62,9 @@ mod tests {
         let mut buf = vec![];
         // assert that the deserialized version is the same as the serialized
         buf.write_element(&el, compression).unwrap();
-        let deserialized: E = buf.read_element(compression).unwrap();
+        let deserialized: E = buf
+            .read_element(compression, CheckForCorrectness::No)
+            .unwrap();
         assert_eq!(el, deserialized);
     }
 
@@ -72,7 +75,7 @@ mod tests {
         let mut buf = vec![];
         // assert that the deserialized version is the same as the serialized
         buf.write_element(&el, compression).unwrap();
-        buf.read_element_preallocated(&mut prealloc, compression)
+        buf.read_element_preallocated(&mut prealloc, compression, CheckForCorrectness::No)
             .unwrap();
         assert_eq!(el, prealloc);
     }
@@ -86,8 +89,12 @@ mod tests {
         let len = len * num_els;
         let mut buf = vec![0; len];
         buf.write_batch(&elements, compression).unwrap();
-        let deserialized1: Vec<E> = buf.read_batch(compression).unwrap();
-        let deserialized2: Vec<E> = buf.read_batch(compression).unwrap();
+        let deserialized1: Vec<E> = buf
+            .read_batch(compression, CheckForCorrectness::No)
+            .unwrap();
+        let deserialized2: Vec<E> = buf
+            .read_batch(compression, CheckForCorrectness::No)
+            .unwrap();
         assert_eq!(elements, deserialized1);
         assert_eq!(elements, deserialized2);
     }
@@ -104,9 +111,9 @@ mod tests {
         buf.write_batch(&elements, compression).unwrap();
         let mut prealloc: Vec<E> = random_point_vec(num_els, &mut rng);
         let mut prealloc2: Vec<E> = random_point_vec(num_els, &mut rng);
-        buf.read_batch_preallocated(&mut prealloc, compression)
+        buf.read_batch_preallocated(&mut prealloc, compression, CheckForCorrectness::No)
             .unwrap();
-        buf.read_batch_preallocated(&mut prealloc2, compression)
+        buf.read_batch_preallocated(&mut prealloc2, compression, CheckForCorrectness::No)
             .unwrap();
         assert_eq!(elements, prealloc);
         assert_eq!(elements, prealloc2);

--- a/snark-utils/src/lib.rs
+++ b/snark-utils/src/lib.rs
@@ -21,6 +21,9 @@ pub use helpers::*;
 mod io;
 pub use io::{buffer_size, BatchDeserializer, BatchSerializer, Deserializer, Serializer};
 
+mod seed;
+pub use seed::derive_rng_from_seed;
+
 // Re-exports for handling hashes
 pub use blake2::digest::generic_array::GenericArray;
 pub use typenum::U64;

--- a/snark-utils/src/lib.rs
+++ b/snark-utils/src/lib.rs
@@ -13,7 +13,7 @@ mod groth16_utils;
 pub use groth16_utils::Groth16Params;
 
 mod elements;
-pub use elements::{ElementType, UseCompression, CheckForCorrectness};
+pub use elements::{CheckForCorrectness, ElementType, UseCompression};
 
 mod helpers;
 pub use helpers::*;

--- a/snark-utils/src/lib.rs
+++ b/snark-utils/src/lib.rs
@@ -13,7 +13,7 @@ mod groth16_utils;
 pub use groth16_utils::Groth16Params;
 
 mod elements;
-pub use elements::{ElementType, UseCompression};
+pub use elements::{ElementType, UseCompression, CheckForCorrectness};
 
 mod helpers;
 pub use helpers::*;

--- a/snark-utils/src/seed.rs
+++ b/snark-utils/src/seed.rs
@@ -1,0 +1,14 @@
+use blake2s_simd::Params;
+use rand_chacha::ChaChaRng;
+use rand::{SeedableRng, Rng};
+
+pub const SEED_PERSONALIZATION: &[u8] = b"CELOSEED";
+
+pub fn derive_rng_from_seed(seed: &[u8]) -> impl Rng {
+    let seed_hash = Params::new()
+        .personal(SEED_PERSONALIZATION)
+        .to_state()
+        .update(seed)
+        .finalize();
+    ChaChaRng::from_seed(*seed_hash.as_array())
+}

--- a/snark-utils/src/seed.rs
+++ b/snark-utils/src/seed.rs
@@ -1,6 +1,6 @@
 use blake2s_simd::Params;
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-use rand::{SeedableRng, Rng};
 
 pub const SEED_PERSONALIZATION: &[u8] = b"CELOSEED";
 

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 snark-utils = { path = "../snark-utils" }
 powersoftau = { path = "../powersoftau" }
 
-zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", version = "0.1.0", features = ["parallel", "full"] }
-zexe_groth16 = { package = "groth16", git = "https://github.com/scipr-lab/zexe", version = "0.1.0", features = ["parallel"] }
-zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", version = "0.1.0" }
+zexe_algebra = { package = "algebra", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel", "full"] }
+zexe_groth16 = { package = "groth16", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1", features = ["parallel"] }
+zexe_r1cs_core = { package = "r1cs-core", git = "https://github.com/scipr-lab/zexe", rev = "38b6f6f2c6b9a6a1b5e8eb90b1287c98b06520d1" }
 
 rand = "0.7.3"
 typenum = "1.11.2"

--- a/test-helpers/src/accumulator_helpers.rs
+++ b/test-helpers/src/accumulator_helpers.rs
@@ -47,9 +47,13 @@ pub fn generate_input<E: PairingEngine>(
     BatchedAccumulator::generate_initial(&mut output, compressed, &parameters).unwrap();
     let mut input = vec![0; len];
     input.copy_from_slice(&output);
-    let before =
-        BatchedAccumulator::deserialize(&output, compressed, CheckForCorrectness::Yes, &parameters)
-            .unwrap();
+    let before = BatchedAccumulator::deserialize(
+        &output,
+        compressed,
+        CheckForCorrectness::Both,
+        &parameters,
+    )
+    .unwrap();
     (input, before)
 }
 

--- a/test-helpers/src/accumulator_helpers.rs
+++ b/test-helpers/src/accumulator_helpers.rs
@@ -1,10 +1,5 @@
-use powersoftau::{
-    keypair::*,
-    parameters::{CeremonyParams, CheckForCorrectness},
-    BatchedAccumulator,
-};
+use powersoftau::{keypair::*, parameters::CeremonyParams, BatchedAccumulator};
 use rand::thread_rng;
-use snark_utils::UseCompression;
 use snark_utils::*;
 use zexe_algebra::PairingEngine;
 
@@ -52,7 +47,9 @@ pub fn generate_input<E: PairingEngine>(
     BatchedAccumulator::generate_initial(&mut output, compressed, &parameters).unwrap();
     let mut input = vec![0; len];
     input.copy_from_slice(&output);
-    let before = BatchedAccumulator::deserialize(&output, compressed, &parameters).unwrap();
+    let before =
+        BatchedAccumulator::deserialize(&output, compressed, CheckForCorrectness::Yes, &parameters)
+            .unwrap();
     (input, before)
 }
 

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -8,8 +8,8 @@ pub use fixtures::TestCircuit;
 use rand::{thread_rng, Rng};
 use zexe_algebra::{AffineCurve, ProjectiveCurve, UniformRand};
 
-pub use snark_utils::UseCompression;
-use snark_utils::{buffer_size, BatchSerializer}; // re-export for testing reasons
+use snark_utils::{buffer_size, BatchSerializer};
+pub use snark_utils::{CheckForCorrectness, UseCompression}; // re-export for testing reasons
 
 /// returns a random affine curve point from the provided rng
 pub fn random_point<C: AffineCurve>(rng: &mut impl Rng) -> C {


### PR DESCRIPTION
This PR implements the division of work into different chunks to work in Optimistic Pipelining and Out-of-Order execution modes. 

Notable changes:
* Randomness is derived from a seed that's loaded from a provided file. This is needed so different chunks would use the same randomness to generate the secret elements. It's specified by the new `--seed` argument.
* The contribution process only works on a slice of powers for a given chunk. The chunk index and chunk size are specified through `--chunk-index` and `--chunk-size`.
* Introduction of a new `combine` command, which combines different chunks to a single larger contribution-like file.
* Verification is divided into two (the original `verify` command has been removed):
  * Verification of Proofs of Knowledge, subgroup membership and non-infinity point testing, which are done on intermediate contributions. This is done by the new command `verify_pok_and_correctness`.
  * Verification of correct ratios between elements, which is done on the combined file. This is done by the new command `verify_ratios`.

The implementation is for Phase 1. A phase 2 implementation will be provided in a separate PR.